### PR TITLE
feat(47): ChromosomeT split — minimal core + LinearChromosome supertrait

### DIFF
--- a/.planning/phases/47-architecture-audit-chromosomet-split/47-STATE.md
+++ b/.planning/phases/47-architecture-audit-chromosomet-split/47-STATE.md
@@ -1,0 +1,14 @@
+---
+phase: 47-architecture-audit-chromosomet-split
+status: planned
+branch: feat/47-chromosomet-split
+target: milestone/v3.0.0
+---
+
+## State
+
+Plans 47-01 through 47-08 are ready. Execution has not started.
+
+## Blockers
+
+None.


### PR DESCRIPTION
## Phase 47 — Architecture Audit & ChromosomeT Split

Splits the all-in-one `ChromosomeT` trait into a minimal evaluation contract and a flat-slice supertrait. This is the **foundation** all other v3.0.0 phases build on.

**What changes**
- `ChromosomeT` shrinks to: `fitness`, `set_fitness`, `calculate_fitness`, `age`, `set_age`, `fitness_distance`
- New `LinearChromosome: ChromosomeT` carries all flat-slice methods (`dna`, `dna_mut`, `set_dna`, `set_fitness_fn`, `new_gene`, `set_gene`, `reset`)
- `Reporter<U>` removed; 6 API simplifications applied
- Wave 0 unit tests lock in both contracts before implementor updates (plans 47-01 through 47-08)
- CI smoke-test validates all 10 examples still compile and run

**Requirements:** ARCH-01, ARCH-02, ARCH-03, ARCH-04, ARCH-05, ARCH-06, ARCH-07  
**Depends on:** Phase 46 (shipped v2.4.0)