### PR TITLE
feat(48): new genotype types — UniqueChromosome, MultiRangeChromosome, MultiUniqueChromosome

### DIFF
--- a/.planning/phases/48-new-genotype-types/48-CONTEXT.md
+++ b/.planning/phases/48-new-genotype-types/48-CONTEXT.md
@@ -1,0 +1,21 @@
+---
+phase: 48-new-genotype-types
+status: planned
+branch: feat/48-new-genotype-types
+target: milestone/v3.0.0
+depends_on: [47]
+---
+
+## Goal
+
+Introduce three purpose-built chromosome types that replace ad-hoc hacks for common problem categories:
+
+- `UniqueChromosome<T>` — permutation problems (no duplicate genes, runtime guard against single-point/uniform crossover)
+- `MultiRangeChromosome<T>` — heterogeneous real-valued spaces with per-gene bounds
+- `MultiUniqueChromosome<T>` — multiple independent permutation groups in one chromosome
+
+Migrate `job_scheduling` example to `UniqueChromosome`.
+
+## Requirements
+
+GEN-01, GEN-02, GEN-03, GEN-04


### PR DESCRIPTION
## Phase 48 — New Genotype Types

Introduces three purpose-built chromosome types to replace ad-hoc hacks for common problem categories.

**New types**
- `UniqueChromosome<T>` — permutation problems; initialises duplicate-free, runtime guard rejects `SinglePoint`/`Uniform` crossover with `GaError`
- `MultiRangeChromosome<T>` — heterogeneous real-valued spaces with per-gene bounds (not a single shared range)
- `MultiUniqueChromosome<T>` — multiple independent permutation groups in one chromosome

**Migration**
- `job_scheduling` example migrated to `UniqueChromosome`

**Requirements:** GEN-01, GEN-02, GEN-03, GEN-04  
**Depends on:** Phase 47