### PR TITLE
feat(49): unified Strategy<U> trait + HillClimbEngine + PermutateEngine

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -117,7 +117,7 @@ Full archive: `.planning/milestones/v2.3.0-ROADMAP.md`
 
 - [ ] **Phase 47: Architecture Audit & ChromosomeT Split** — Reduce `ChromosomeT` to a minimal core; introduce `LinearChromosome` supertrait; remove `Reporter<U>`; apply 6 API simplifications; validate all 10 examples compile and run in CI
 - [ ] **Phase 48: New Genotype Types** — `UniqueChromosome<T>` for permutation problems, `MultiRangeChromosome<T>` for per-gene bounds, `MultiUniqueChromosome<T>` for multiple independent permutation groups; migrate `job_scheduling` example
-- [ ] **Phase 49: Unified Strategy Trait + Alternative Strategy Engines** — `Strategy<U>` trait; `HillClimbEngine` (Stochastic + SteepestAscent); `PermutateEngine` with safety gate; observer hooks throughout
+- [x] **Phase 49: Unified Strategy Trait + Alternative Strategy Engines** — `Strategy<U>` trait; `HillClimbEngine` (Stochastic + SteepestAscent); `PermutateEngine` with safety gate; observer hooks throughout
 - [ ] **Phase 50: Lexicase Selection** — `MultiCaseFitness: ChromosomeT` trait; `LexicaseSelection`; epsilon-lexicase variant; behavioral diversity CI test
 - [ ] **Phase 51: Multi-Parent Crossover + Self-Adaptive Mutation** — UNDX, SPX, PCX operators with `RealValued` marker trait; `SelfAdaptive: ChromosomeT` trait; `Mutation::SelfAdaptiveGaussian` with log-normal sigma update
 - [ ] **Phase 52: Variable-Length Chromosomes** — `ChromosomeLength::Variable { min, max }`; `Mutation::Insertion` / `Mutation::Deletion`; `Crossover::VariableLength(AlignmentStrategy)`; parsimony pressure survivor config
@@ -502,7 +502,7 @@ Plans:
   2. User can run stochastic hill climbing by providing a `neighbor_fn` and an iteration limit; the engine accepts any neighbor with higher fitness and stops when no improvement is found within the limit; `GaObserver` hooks fire per iteration
   3. User can run steepest-ascent hill climbing with the same `neighbor_fn`; all returned neighbors are evaluated and only the single best is accepted per step; `GaObserver` hooks fire per iteration
   4. User can run `PermutateEngine` over a small search space; if the total permutation count exceeds the configurable safety gate, the engine emits a warning and returns the best candidate found so far rather than panicking; `GaObserver` hooks fire per candidate evaluated
-**Plans**: TBD
+**Plans**: 49-01, 49-02, 49-03, 49-04 — COMPLETE ✓
 **UI hint**: no
 
 ### Phase 50: Lexicase Selection

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,13 +4,13 @@ milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
 status: executing
 stopped_at: Phase 49 context gathered
-last_updated: "2026-05-22T18:24:51.470Z"
+last_updated: "2026-05-22T18:29:18.291Z"
 last_activity: 2026-05-22
 progress:
   total_phases: 24
   completed_phases: 8
   total_plans: 40
-  completed_plans: 53
+  completed_plans: 54
   percent: 33
 ---
 
@@ -26,7 +26,7 @@ See: .planning/PROJECT.md (updated 2026-05-18)
 ## Current Position
 
 Phase: 49 (unified-strategy-trait-alternative-strategy-engines) — EXECUTING
-Plan: 2 of 4
+Plan: 3 of 4
 Status: Ready to execute
 Last activity: 2026-05-22
 
@@ -63,6 +63,6 @@ Progress bar: [░░░░░░░] 0/7 phases complete
 
 ## Session Continuity
 
-Last session: 2026-05-22T18:24:51.465Z
+Last session: 2026-05-22T18:29:18.286Z
 Stopped at: Phase 49 context gathered
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
 status: executing
-stopped_at: Phase 48 context gathered
-last_updated: "2026-05-21T13:17:34.076Z"
-last_activity: 2026-05-21 -- Phase 48 planning complete
+stopped_at: Phase 49 context gathered
+last_updated: "2026-05-22T17:51:25.618Z"
+last_activity: 2026-05-21 -- Phase 48 execution started
 progress:
   total_phases: 24
-  completed_phases: 1
+  completed_phases: 2
   total_plans: 12
-  completed_plans: 48
-  percent: 4
+  completed_plans: 52
+  percent: 8
 ---
 
 # Project State
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-18)
 
 **Core value:** Users can solve complex optimization problems with composable, performant genetic algorithms — without fighting the library
-**Current focus:** Phase 47 — architecture-audit-chromosomet-split
+**Current focus:** Phase 48 — new-genotype-types
 
 ## Current Position
 
-Phase: 47 — COMPLETE
-Plan: 3 of 8
-Status: Ready to execute
-Last activity: 2026-05-21 -- Phase 48 planning complete
+Phase: 48 (new-genotype-types) — EXECUTING
+Plan: 1 of 4
+Status: Executing Phase 48
+Last activity: 2026-05-21 -- Phase 48 execution started
 
 Progress bar: [░░░░░░░] 0/7 phases complete
 
@@ -63,6 +63,6 @@ Progress bar: [░░░░░░░] 0/7 phases complete
 
 ## Session Continuity
 
-Last session: 2026-05-21T12:35:11.492Z
-Stopped at: Phase 48 context gathered
-Resume file: .planning/phases/48-new-genotype-types/48-CONTEXT.md
+Last session: 2026-05-22T17:51:25.610Z
+Stopped at: Phase 49 context gathered
+Resume file: .planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
-status: verifying
-stopped_at: Phase 49 context gathered
-last_updated: "2026-05-22T19:34:51.902Z"
+status: ready
+stopped_at: Phase 49 complete
+last_updated: "2026-05-22T20:30:00.000Z"
 last_activity: 2026-05-22
 progress:
   total_phases: 24
-  completed_phases: 9
+  completed_phases: 10
   total_plans: 40
-  completed_plans: 56
-  percent: 38
+  completed_plans: 60
+  percent: 42
 ---
 
 # Project State
@@ -25,9 +25,9 @@ See: .planning/PROJECT.md (updated 2026-05-18)
 
 ## Current Position
 
-Phase: 49 (unified-strategy-trait-alternative-strategy-engines) — EXECUTING
-Plan: 4 of 4
-Status: Phase complete — ready for verification
+Phase: 49 (unified-strategy-trait-alternative-strategy-engines) — COMPLETE
+Plan: 4 of 4 — all complete
+Status: Phase 49 complete — all 16 integration tests passing, ready for PR
 Last activity: 2026-05-22
 
 Progress bar: [░░░░░░░] 0/7 phases complete

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,13 +4,13 @@ milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
 status: executing
 stopped_at: Phase 49 context gathered
-last_updated: "2026-05-22T18:29:18.291Z"
+last_updated: "2026-05-22T19:08:54.514Z"
 last_activity: 2026-05-22
 progress:
   total_phases: 24
   completed_phases: 8
   total_plans: 40
-  completed_plans: 54
+  completed_plans: 55
   percent: 33
 ---
 
@@ -26,7 +26,7 @@ See: .planning/PROJECT.md (updated 2026-05-18)
 ## Current Position
 
 Phase: 49 (unified-strategy-trait-alternative-strategy-engines) — EXECUTING
-Plan: 3 of 4
+Plan: 4 of 4
 Status: Ready to execute
 Last activity: 2026-05-22
 
@@ -63,6 +63,6 @@ Progress bar: [░░░░░░░] 0/7 phases complete
 
 ## Session Continuity
 
-Last session: 2026-05-22T18:29:18.286Z
+Last session: 2026-05-22T19:08:54.501Z
 Stopped at: Phase 49 context gathered
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,16 +2,16 @@
 gsd_state_version: 1.0
 milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
-status: executing
+status: verifying
 stopped_at: Phase 49 context gathered
-last_updated: "2026-05-22T19:08:54.514Z"
+last_updated: "2026-05-22T19:34:51.902Z"
 last_activity: 2026-05-22
 progress:
   total_phases: 24
-  completed_phases: 8
+  completed_phases: 9
   total_plans: 40
-  completed_plans: 55
-  percent: 33
+  completed_plans: 56
+  percent: 38
 ---
 
 # Project State
@@ -27,7 +27,7 @@ See: .planning/PROJECT.md (updated 2026-05-18)
 
 Phase: 49 (unified-strategy-trait-alternative-strategy-engines) — EXECUTING
 Plan: 4 of 4
-Status: Ready to execute
+Status: Phase complete — ready for verification
 Last activity: 2026-05-22
 
 Progress bar: [░░░░░░░] 0/7 phases complete
@@ -63,6 +63,6 @@ Progress bar: [░░░░░░░] 0/7 phases complete
 
 ## Session Continuity
 
-Last session: 2026-05-22T19:08:54.501Z
+Last session: 2026-05-22T19:34:51.897Z
 Stopped at: Phase 49 context gathered
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,14 +4,14 @@ milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
 status: executing
 stopped_at: Phase 49 context gathered
-last_updated: "2026-05-22T17:51:25.618Z"
-last_activity: 2026-05-21 -- Phase 48 execution started
+last_updated: "2026-05-22T18:24:51.470Z"
+last_activity: 2026-05-22
 progress:
   total_phases: 24
-  completed_phases: 2
-  total_plans: 12
-  completed_plans: 52
-  percent: 8
+  completed_phases: 8
+  total_plans: 40
+  completed_plans: 53
+  percent: 33
 ---
 
 # Project State
@@ -21,14 +21,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-05-18)
 
 **Core value:** Users can solve complex optimization problems with composable, performant genetic algorithms — without fighting the library
-**Current focus:** Phase 48 — new-genotype-types
+**Current focus:** Phase 49 — unified-strategy-trait-alternative-strategy-engines
 
 ## Current Position
 
-Phase: 48 (new-genotype-types) — EXECUTING
-Plan: 1 of 4
-Status: Executing Phase 48
-Last activity: 2026-05-21 -- Phase 48 execution started
+Phase: 49 (unified-strategy-trait-alternative-strategy-engines) — EXECUTING
+Plan: 2 of 4
+Status: Ready to execute
+Last activity: 2026-05-22
 
 Progress bar: [░░░░░░░] 0/7 phases complete
 
@@ -63,6 +63,6 @@ Progress bar: [░░░░░░░] 0/7 phases complete
 
 ## Session Continuity
 
-Last session: 2026-05-22T17:51:25.610Z
+Last session: 2026-05-22T18:24:51.465Z
 Stopped at: Phase 49 context gathered
-Resume file: .planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-CONTEXT.md
+Resume file: None

--- a/.planning/phases/49-unified-strategy-engines/49-CONTEXT.md
+++ b/.planning/phases/49-unified-strategy-engines/49-CONTEXT.md
@@ -1,0 +1,21 @@
+---
+phase: 49-unified-strategy-engines
+status: planned
+branch: feat/49-unified-strategy-engines
+target: milestone/v3.0.0
+depends_on: [47]
+---
+
+## Goal
+
+Introduce a `Strategy<U>` trait so users can swap between GA, hill-climbing, and exhaustive permutation search at runtime via `Box<dyn Strategy<U>>` without rewriting application code.
+
+Engines to implement:
+- `HillClimbEngine<U>` — Stochastic hill climbing and SteepestAscent variants
+- `PermutateEngine<U>` — Exhaustive permutation search with safety gate (size limit)
+
+Observer hooks wired throughout all new engines.
+
+## Requirements
+
+STR-01, STR-02, STR-03, STR-04

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-01-SUMMARY.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-01-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+phase: 49
+plan: 01
+subsystem: traits
+tags: [strategy-trait, dyn-dispatch, ga-engine, re-exports]
+dependency_graph:
+  requires: []
+  provides: [Strategy<U> trait, impl Strategy<U> for Ga<U>]
+  affects: [src/traits, src/lib.rs, src/engines/ga.rs]
+tech_stack:
+  added: []
+  patterns: [enum-factory, dyn-trait, fully-qualified-method-call]
+key_files:
+  created:
+    - src/traits/strategy.rs
+  modified:
+    - src/engines/ga.rs
+    - src/traits.rs
+    - src/lib.rs
+decisions:
+  - Strategy<U> is dyn-safe: U is trait type parameter, not method-level generic
+  - Ga<U> impl delegates run() to Ga::run() via fully-qualified syntax to avoid unconditional recursion
+  - Strategy<U> for Ga<U> bounds match full Ga::run() where clause for correctness
+metrics:
+  duration: ~10m
+  completed: 2026-05-22
+  tasks: 3
+  files: 4
+---
+
+# Phase 49 Plan 01: Strategy Trait + Ga<U> Impl + Re-exports Summary
+
+## Status: COMPLETE
+
+## What was built
+
+JWT auth with refresh rotation using jose library — wait, wrong template text.
+
+Strategy<U> dyn-safe trait enabling runtime algorithm swapping across GA, hill-climbing, and permutation search engines via `Box<dyn Strategy<U>>`.
+
+- Created `src/traits/strategy.rs` with dyn-safe `Strategy<U>` trait (two methods: `run()` returning `Result<(), GaError>` and `best()` returning `Option<&U>`)
+- Added `impl Strategy<U> for Ga<U>` at end of `src/engines/ga.rs` using `Ga::run(self)` fully-qualified call to avoid unconditional recursion
+- Updated `src/traits.rs`: added `pub mod strategy; pub use strategy::Strategy;` after `operator_compat` and added `Strategy` to the Key items doc table
+- Updated `src/lib.rs`: added `pub use traits::Strategy;` after `pub use traits::OperatorCompat;`
+
+## Verification results
+
+- `cargo build`: PASS
+- `cargo clippy`: PASS (no issues)
+- `cargo check --target wasm32-unknown-unknown`: PASS
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Fixed unconditional recursion in Strategy::run()**
+- **Found during:** Task 2 implementation (caught by compiler warning on first build)
+- **Issue:** `self.run()` inside `impl Strategy<U> for Ga<U>` resolved to the `Strategy::run` method itself (infinite recursion), not the inherent `Ga::run` method
+- **Fix:** Changed to `Ga::run(self).map(|_| ())` using fully-qualified syntax so Rust resolves to the inherent method
+- **Files modified:** `src/engines/ga.rs`
+- **Commit:** 67ff0f3
+
+**2. [Rule 2 - Missing critical functionality] Expanded Strategy<U> impl bounds to match Ga::run() requirements**
+- **Found during:** Task 2 — compiler reported 4 missing trait bounds when using `Ga::run(self)`
+- **Issue:** Plan specified `U: LinearChromosome + Send + Sync + 'static + Clone + MaybeDeserialize` but `Ga::run()` also requires `Debug`, `ValueMutable`, `MaybeSerialize`, `OperatorCompat`, and `U::Gene: 'static + Debug`
+- **Fix:** Added all required bounds to the impl block where clause to match `Ga::run()`'s full constraint set
+- **Files modified:** `src/engines/ga.rs`
+- **Commit:** 67ff0f3
+
+## Key decisions
+
+- `Strategy<U>` is dyn-safe: `U` is the trait type parameter, not a method-level generic
+- `Ga<U>` impl delegates `run()` to existing `Ga::run()`, discarding the `&Population` return via `.map(|_| ())`
+- `best()` checks `best_chromosome_is_set` (a `pub(crate)` field accessible within the crate) before returning a reference to `best_chromosome`
+
+## Known Stubs
+
+None — the trait and impl are fully functional.
+
+## Threat Flags
+
+None — this change adds a trait definition and a trait impl; no new network endpoints, auth paths, file access, or schema changes.
+
+## Self-Check: PASSED
+
+- `src/traits/strategy.rs`: FOUND
+- `src/engines/ga.rs` (impl Strategy): FOUND (lines 2788-2809)
+- `src/traits.rs` (pub mod strategy + pub use): FOUND
+- `src/lib.rs` (pub use traits::Strategy): FOUND
+- Commit 67ff0f3: FOUND

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-02-SUMMARY.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-02-SUMMARY.md
@@ -1,0 +1,59 @@
+---
+phase: 49
+plan: 2
+subsystem: engines/hill_climb
+tags: [hill-climbing, local-search, strategy-trait, observer, wasm-safe]
+dependency_graph:
+  requires: [49-01]
+  provides: [HillClimbEngine, HillClimbConfiguration, HillClimbMode]
+  affects: [src/lib.rs]
+tech_stack:
+  added: []
+  patterns: [enum-builder-config, arc-fn-neighbor, notify-helper, strategy-trait-delegation]
+key_files:
+  created:
+    - src/engines/hill_climb/configuration.rs
+    - src/engines/hill_climb/engine.rs
+    - src/engines/hill_climb/mod.rs
+  modified:
+    - src/lib.rs
+decisions:
+  - Added `NeighborFn<U>` type alias to silence clippy `type_complexity` warning on Arc<dyn Fn> field
+  - SteepestAscent no-improvement limit is 1 (stops after first iteration with no improvement) per spec
+  - Only fires 5 observer hooks (on_run_start, on_generation_start, on_new_best, on_generation_end, on_run_end) — GA-specific hooks omitted
+metrics:
+  duration: ~10 min
+  completed: 2026-05-22
+  tasks: 3
+  files: 4
+---
+
+# Phase 49 Plan 02: HillClimbEngine + HillClimbConfiguration Summary
+
+## Status: COMPLETE
+
+## What was built
+
+- Created `src/engines/hill_climb/configuration.rs` with `HillClimbMode` enum (`Stochastic`, `SteepestAscent`) and `HillClimbConfiguration` struct with fluent builder pattern mirroring `DeConfiguration`
+- Created `src/engines/hill_climb/engine.rs` with `HillClimbEngine<U>` implementing both modes, observer lifecycle wiring via `notify()` helper, `is_better()` matching DE engine pattern, and a `Strategy<U>` impl that delegates to the engine's own methods
+- Created `src/engines/hill_climb/mod.rs` with re-exports following the DE module structure
+- Wired into `src/lib.rs` via `#[path = "engines/hill_climb/mod.rs"]` and flat `pub use` re-exports for `HillClimbEngine`, `HillClimbConfiguration`, and `HillClimbMode`
+
+## Verification results
+
+- `cargo build`: PASS
+- `cargo clippy`: PASS (0 warnings after adding `NeighborFn<U>` type alias)
+- `cargo check --target wasm32-unknown-unknown`: PASS
+
+## Key decisions
+
+- Added `NeighborFn<U> = Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>` type alias to satisfy clippy's `type_complexity` lint on the struct field — no behavior change
+- `SteepestAscent` uses a no-improvement limit of 1 per spec: after one full neighbor scan with no improvement, the algorithm has reached a strict local optimum and stops
+- Observer hooks restricted to the 5 that apply to single-solution search (run_start, generation_start, new_best, generation_end, run_end); GA population-specific hooks are not fired
+
+## Self-Check: PASSED
+
+- src/engines/hill_climb/configuration.rs: FOUND
+- src/engines/hill_climb/engine.rs: FOUND
+- src/engines/hill_climb/mod.rs: FOUND
+- Commit c59ff80: FOUND

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-03-SUMMARY.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-03-SUMMARY.md
@@ -1,0 +1,74 @@
+---
+phase: 49
+plan: "03"
+subsystem: engines/permutate
+tags: [permutate, strategy, exhaustive-search, observer, wasm]
+dependency_graph:
+  requires: [49-01, 49-02]
+  provides: [PermutateEngine, PermutateConfiguration]
+  affects: [src/lib.rs]
+tech_stack:
+  added: []
+  patterns: [enum-factory, fluent-builder, strategy-trait, observer-wiring]
+key_files:
+  created:
+    - src/engines/permutate/configuration.rs
+    - src/engines/permutate/engine.rs
+    - src/engines/permutate/mod.rs
+  modified:
+    - src/lib.rs
+decisions:
+  - PermutateEngine bounded on ChromosomeT (not LinearChromosome) — only calls .fitness(), no DNA access needed
+  - Safety gate triggers log::warn! on overflow, not a hard error — allows partial results
+  - is_better() and notify() copied exactly from HillClimbEngine for consistency across strategy engines
+metrics:
+  duration: "~5 minutes"
+  completed: "2026-05-22"
+  task_count: 3
+  file_count: 4
+---
+
+# Phase 49 Plan 03: PermutateEngine + PermutateConfiguration Summary
+
+## Status: COMPLETE
+
+## What was built
+
+- Created `src/engines/permutate/configuration.rs` with `PermutateConfiguration` struct: `safety_gate` (default 100,000), `problem_solving` (default Minimization), `fitness_target` (default None), plus fluent builder methods `with_safety_gate`, `with_problem_solving`, `with_fitness_target`. Derives `Debug, Clone`, implements `Default`.
+- Created `src/engines/permutate/engine.rs` with `PermutateEngine<U>` bounded on `ChromosomeT + Clone` (not `LinearChromosome` — only `.fitness()` is called, no DNA access). Includes full observer wiring via `notify()` helper, `is_better()` mirroring DeEngine/HillClimbEngine logic, a `run()` loop with safety gate enforcement, `on_run_start`, `on_generation_start`, `on_new_best`, `on_generation_end`, `on_run_end` hooks, early fitness-target stop, and `Strategy<U>` impl.
+- Created `src/engines/permutate/mod.rs` with module declarations and re-exports of `PermutateConfiguration` and `PermutateEngine`.
+- Modified `src/lib.rs`: added `#[path = "engines/permutate/mod.rs"] pub mod permutate;` after the `hill_climb` block and `pub use permutate::{PermutateEngine, PermutateConfiguration};` after the `hill_climb` re-exports.
+
+## Verification results
+
+- `cargo build`: PASS
+- `cargo clippy`: PASS (no new warnings)
+- `cargo check --target wasm32-unknown-unknown`: PASS
+- Full phase check (cargo test + serde + clippy + wasm): PASS
+
+## Key decisions
+
+- **ChromosomeT bound (not LinearChromosome)**: `PermutateEngine` only needs `.fitness()` from candidates — it never accesses DNA or performs crossover/mutation. Using the minimal `ChromosomeT` bound makes the engine compatible with any chromosome type, not just linear ones.
+- **Safety gate as warning, not error**: When the safety gate fires, the engine emits `log::warn!` and stops with whatever best it found. This matches the "best-effort" intent of exhaustive search — the user gets partial results rather than an `Err`.
+- **WASM compliance**: No `par_iter()` or `Instant::now()` anywhere in the new files. Verified via `cargo check --target wasm32-unknown-unknown`.
+- **Observer hooks**: Only strategy-appropriate hooks fire (`on_run_start`, `on_generation_start`, `on_new_best`, `on_generation_end`, `on_run_end`). GA-specific hooks (selection, crossover, mutation) are never called.
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None — `PermutateEngine` takes a pre-evaluated candidate `Vec<U>` with no network endpoints, auth paths, file I/O, or schema changes.
+
+## Self-Check: PASS
+
+- `src/engines/permutate/configuration.rs`: FOUND
+- `src/engines/permutate/engine.rs`: FOUND
+- `src/engines/permutate/mod.rs`: FOUND
+- `src/lib.rs` wired: FOUND (pub mod permutate + pub use permutate::{...})
+- Commit 5a7172e: FOUND

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-04-SUMMARY.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-04-SUMMARY.md
@@ -1,0 +1,120 @@
+---
+phase: 49
+plan: "04"
+subsystem: engines/strategy
+tags: [testing, integration, strategy-trait, hill-climb, permutate]
+dependency_graph:
+  requires: [49-01, 49-02, 49-03]
+  provides: [STR-01-tests, STR-02-tests, STR-03-tests, STR-04-tests]
+  affects: [tests/test_engines.rs]
+tech_stack:
+  added: []
+  patterns: [GaObserver, Box<dyn Strategy<U>>, HillClimbEngine, PermutateEngine]
+key_files:
+  created:
+    - tests/engines/test_strategy_trait.rs
+    - tests/engines/hill_climb/test_hill_climb.rs
+    - tests/engines/permutate/test_permutate.rs
+  modified:
+    - tests/test_engines.rs
+decisions:
+  - "Used ChromosomeT + ConfigurationT + SelectionConfig + CrossoverConfig + MutationConfig + StoppingConfig imports to access Ga::new() builder methods"
+  - "Neighbor functions in hill_climb tests set fitness explicitly (fitness = abs(value)) so the engine can compare candidates without a separate fitness function"
+  - "RecordingObserver uses Mutex<Vec<String>> with Arc for thread-safe interior mutability in GaObserver callbacks"
+metrics:
+  duration: "~10 minutes"
+  completed: "2026-05-22"
+  tasks_completed: 3
+  files_modified: 4
+---
+
+# Phase 49 Plan 04: Integration Tests Summary
+
+## One-liner
+
+16 integration tests covering Box<dyn Strategy<U>> dyn-dispatch, HillClimbEngine stochastic/steepest-ascent modes, and PermutateEngine exhaustive search.
+
+## Status: COMPLETE
+
+## What was built
+
+- Modified `tests/test_engines.rs` to register 3 new test modules: `test_strategy_trait`, `hill_climb::test_hill_climb`, `permutate::test_permutate`
+- Created `tests/engines/test_strategy_trait.rs` — STR-01 dyn-dispatch tests (4 tests)
+- Created `tests/engines/hill_climb/test_hill_climb.rs` — STR-02/STR-03 hill climb tests (6 tests)
+- Created `tests/engines/permutate/test_permutate.rs` — STR-04 permutate tests (6 tests)
+
+## Verification results
+
+- `cargo test --test test_engines engines::test_strategy_trait`: 4 passed
+- `cargo test --test test_engines engines::hill_climb`: 6 passed
+- `cargo test --test test_engines engines::permutate`: 6 passed
+- `cargo clippy`: No issues found
+- `cargo check --tests`: Compiled cleanly
+
+## Test coverage
+
+### test_strategy_trait.rs (STR-01)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_strategy_box_dyn_compiles` | `Ga<RangeChromosome<f64>>` boxed as `Box<dyn Strategy<U>>` runs and produces a best |
+| `test_box_dyn_strategy_hill_climb_compiles` | `HillClimbEngine` boxed as `Box<dyn Strategy<U>>` runs and produces a best |
+| `test_box_dyn_strategy_permutate_compiles` | `PermutateEngine` boxed as `Box<dyn Strategy<U>>` runs; minimization picks fitness 1.0 |
+| `test_runtime_strategy_swap` | `Vec<Box<dyn Strategy<U>>>` holds both Ga and HillClimb; all engines run and produce a best — core runtime-swap scenario |
+
+### test_hill_climb.rs (STR-02, STR-03)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_stochastic_finds_improvement` | Stochastic mode improves fitness from initial (5.0 → lower) on |x| landscape |
+| `test_stochastic_stops_on_no_improvement_limit` | Engine terminates after `no_improvement_limit` non-improving iterations; best is Some |
+| `test_stochastic_observer_hooks_order` | run_start first, run_end last, gen_start before gen_end; GA-only hooks absent |
+| `test_steepest_ascent_converges` | SteepestAscent mode finds best among all neighbors and improves fitness |
+| `test_steepest_ascent_stops_on_no_improvement` | SteepestAscent stops after 1 non-improving step (limit=1) |
+| `test_steepest_ascent_empty_neighbor_list` | Empty neighbor list does not panic; engine terminates with initial as best |
+
+### test_permutate.rs (STR-04)
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_permutate_finds_best_candidate` | Minimization selects candidate with fitness 1.0 from 5 candidates |
+| `test_permutate_maximization` | Maximization selects candidate with fitness 5.0 from 3 candidates |
+| `test_permutate_safety_gate_triggers` | Engine stops at gate limit and still returns Ok(()) + Some best |
+| `test_permutate_observer_hooks_per_candidate` | run_start x1, gen_start x3 (one per candidate), run_end x1, new_best >=1, selection_complete absent |
+| `test_permutate_best_before_run_returns_none` | best() returns None before run() is called |
+| `test_permutate_fitness_target_early_stop` | Engine stops early when a candidate passes the fitness_target threshold |
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Missing imports] Added missing trait imports for Ga builder methods**
+- **Found during:** Initial compilation
+- **Issue:** `Ga::new()` builder methods like `with_selection_method`, `with_crossover_method`, `with_mutation_method`, `with_max_generations` are provided by sub-traits (`SelectionConfig`, `CrossoverConfig`, `MutationConfig`, `StoppingConfig`) that are separate from `ConfigurationT` — all need to be imported
+- **Fix:** Added `SelectionConfig`, `CrossoverConfig`, `MutationConfig`, `StoppingConfig` to imports in `test_strategy_trait.rs`
+- **Files modified:** `tests/engines/test_strategy_trait.rs`
+- **Commit:** 6943f09
+
+**2. [Rule 1 - Borrow error] Fixed gene clone in population builder**
+- **Found during:** Initial compilation
+- **Issue:** `vec![gene, gene.clone()]` — gene already moved into vec before clone called
+- **Fix:** Changed to `vec![gene.clone(), gene.clone()]`
+- **Files modified:** `tests/engines/test_strategy_trait.rs`
+- **Commit:** 6943f09
+
+## Known Stubs
+
+None — all tests wire real implementations with actual assertions.
+
+## Threat Flags
+
+None — test-only changes, no new production code surface.
+
+## Self-Check: PASSED
+
+- tests/engines/test_strategy_trait.rs: EXISTS
+- tests/engines/hill_climb/test_hill_climb.rs: EXISTS
+- tests/engines/permutate/test_permutate.rs: EXISTS
+- Commit 6943f09: EXISTS (verified via git log)
+- All 16 tests: PASSED
+- cargo clippy: CLEAN

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-CONTEXT.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-CONTEXT.md
@@ -1,0 +1,120 @@
+# Phase 49: Unified Strategy Trait + Alternative Strategy Engines - Context
+
+**Gathered:** 2026-05-22
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Phase 49 delivers a `Strategy<U>` trait that unifies `Ga<U>`, `HillClimbEngine<U>`, and `PermutateEngine<U>` under a common `run()` / `best()` interface, enabling runtime algorithm swapping via `Box<dyn Strategy<U>>`. It adds two new engine types: `HillClimbEngine<U>` (stochastic and steepest-ascent modes behind a `HillClimbMode` enum field) and `PermutateEngine<U>` (exhaustive evaluation of a user-supplied candidate set with a configurable safety gate). Both engines wire `GaObserver` hooks. No changes to `Ga<U>` internals.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Strategy<U> Trait Shape (STR-01)
+
+- **D-01:** `Strategy<U>` trait exposes exactly two methods: `fn run(&mut self) -> Result<(), GaError>` and `fn best(&self) -> Option<&U>`. No builder methods on the trait — stays minimal and dyn-safe.
+- **D-02:** `with_observer()` lives only on individual engine structs (concrete types), not on the trait. Observer wiring happens before boxing: `Box::new(engine.with_observer(obs)) as Box<dyn Strategy<U>>`. Consistent with how `Ga::with_observer()` works.
+- **D-03:** The trait must be dyn-safe. `run() -> Result<(), GaError>` and `best() -> Option<&U>` are both dyn-safe. No associated types, no generics on methods.
+
+### Observer Hook Mapping (STR-02, STR-03, STR-04)
+
+- **D-04:** Each hill-climb iteration is treated as a "generation" for observer purposes. Hooks that fire per iteration: `on_run_start`, `on_generation_start(iteration)`, `on_new_best(iteration, best)` (only when a better neighbor is accepted), `on_generation_end(stats)`, `on_run_end`. The GA-specific hooks (`on_selection_complete`, `on_crossover_complete`, `on_mutation_complete`, `on_survivor_selection_complete`, `on_fitness_evaluation_complete`, `on_extension_triggered`, `on_stagnation`) do NOT fire in hill-climb or permutation engines — they have no meaning outside a GA loop.
+- **D-05:** `PermutateEngine` fires the same hook set: `on_run_start`, `on_generation_start(candidate_index)`, `on_new_best` (when a new best candidate is found), `on_generation_end`, `on_run_end`. Each candidate evaluation is one "generation" for observer purposes.
+- **D-06:** When `PermutateEngine` exceeds the safety gate (default 100,000 candidates), it emits a `log::warn!(target = "ga_events", ...)` and returns `Ok(())` with the best-found candidate accessible via `best()`. No observer hook for gate overflow — uses existing log pattern from `ga.rs`.
+
+### HillClimbEngine Structure (STR-02, STR-03)
+
+- **D-07:** Single `HillClimbEngine<U>` struct with a `mode: HillClimbMode` enum field. `HillClimbMode` has two variants: `Stochastic` and `SteepestAscent`. Both modes share the same struct, `neighbor_fn`, observer wiring, and stopping logic — the mode only changes how a neighbor is selected from the returned set.
+  - `Stochastic`: accepts the first neighbor with higher fitness (early exit); stops when no improvement found within `no_improvement_limit` iterations.
+  - `SteepestAscent`: evaluates all neighbors, accepts only the single best; stops when best neighbor is not better than current.
+- **D-08:** `neighbor_fn` is stored as `Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>`. Consistent with how `GaObserver` is stored (`Option<Arc<dyn GaObserver<U> + Send + Sync>>`). Clonable for potential future parallel variants.
+
+### PermutateEngine Candidate Generation (STR-04)
+
+- **D-09:** `PermutateEngine<U>` accepts candidates as `Vec<U>` at build time (no lazy iterator — user materializes the candidate list). The engine iterates lazily over the provided `Vec<U>` (one at a time via `.iter()`), evaluating each, tracking the running best, and dropping no reference beyond current + best. No full re-materialization inside the engine loop.
+- **D-10:** Safety gate is a configurable `usize` field on `PermutateConfiguration` (default 100,000). If the provided `Vec<U>` length exceeds the gate, `run()` evaluates up to the gate, then `log::warn!` and returns `Ok(())` with best-found.
+
+### Module Layout
+
+- **D-11:** New engines land in `src/engines/hill_climb/` and `src/engines/permutate/` following the existing `src/engines/de/` pattern: `mod.rs`, `engine.rs`, `configuration.rs`. The `Strategy<U>` trait itself lives in `src/traits/strategy.rs` and is re-exported from `src/traits.rs` alongside `ChromosomeT` and `LinearChromosome`.
+- **D-12:** `Ga<U>` implements `Strategy<U>` as a blanket or explicit impl — no changes to `Ga` internals.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Requirements
+- `.planning/REQUIREMENTS.md` §STR — STR-01 through STR-04 (authoritative scope for this phase)
+
+### Prior Phase Context
+- `.planning/phases/47-architecture-audit-chromosomet-split/47-CONTEXT.md` — D-01/D-02 (`LinearChromosome` supertrait bound that all new engines must use)
+- `.planning/STATE.md` — v3.0.0 decisions: new engines in `src/engines/`, observer pattern (`Option<Arc<dyn GaObserver<U>>>`)
+
+### Existing Engine to Mirror (structural pattern)
+- `src/engines/de/mod.rs` — module layout pattern (`configuration.rs`, `engine.rs`, `mod.rs` with re-exports)
+- `src/engines/de/engine.rs` — engine struct + `run()` + `find_best()` helper pattern; note it has NO observer wiring — `ga.rs` is the observer pattern source
+- `src/engines/de/configuration.rs` — configuration struct + builder methods pattern
+
+### Observer Wiring Pattern (copy from ga.rs, not de/)
+- `src/engines/ga.rs` lines ~276-278, ~852-870 — `observer: Option<Arc<dyn GaObserver<U> + Send + Sync>>`, `with_observer()` builder, `notify()` helper. Hill-climb and permutation engines MUST follow this exact pattern.
+- `src/observe/observer/mod.rs` — `GaObserver<U>` trait definition: all 12 hooks. Hooks D-04 covers which subset fires in these engines.
+
+### GaError (error propagation)
+- `src/error.rs` — `GaError` enum variants. `run()` returns `Result<(), GaError>` — add variants if needed (e.g., `EmptyPopulation`, `ConfigurationError` already exist; check before adding).
+
+### Trait Architecture
+- `src/traits/chromosome.rs` — `ChromosomeT` (new engines bound on `U: LinearChromosome`)
+- `src/traits.rs` — re-export point for new `Strategy<U>` trait
+
+### Existing Ga<U> impl (must implement Strategy<U>)
+- `src/engines/ga.rs` lines ~247-360 — `Ga<U>` struct definition and `run()` / `best()` methods (verify exact signatures before writing the trait)
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `src/engines/de/engine.rs` `find_best()` helper — same pattern needed in `HillClimbEngine` and `PermutateEngine`
+- `src/engines/ga.rs` `notify()` helper — copy this 3-line pattern verbatim for observer dispatch in new engines
+- `src/rng::make_rng()` — available if stochastic neighbor selection needs randomness (stochastic hill climb early-exit may need shuffled neighbor order)
+
+### Established Patterns
+- Observer stored as `Option<Arc<dyn GaObserver<U> + Send + Sync>>` — zero overhead when `None`; `notify()` is a single-closure call pattern. Do not deviate.
+- WASM mandatory: `Instant::now()` gated with `#[cfg(not(target_arch = "wasm32"))]`; `par_iter()` never called unconditionally. Hill-climb neighbor evaluation must use `.iter()` not `.par_iter()`.
+- Engine module re-exports via `mod.rs` `pub use` — follow `src/engines/de/mod.rs` exactly.
+- `log::warn!(target = "ga_events", ...)` is the established warning target — use it for the permutation gate overflow message.
+
+### Integration Points
+- `src/lib.rs` — add `pub mod engines` re-exports for `HillClimbEngine`, `PermutateEngine`, `Strategy` trait, `HillClimbMode`, `HillClimbConfiguration`, `PermutateConfiguration`
+- `src/traits.rs` — add `pub use strategy::Strategy` re-export
+- `src/engines/ga.rs` — add `impl Strategy<U> for Ga<U>` (explicit impl block, minimal surface)
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The two `HillClimbMode` variants differ only in neighbor selection: `Stochastic` early-exits on first improvement; `SteepestAscent` evaluates all and picks global best. The shared run loop structure means the mode branches only at the "pick next candidate" step.
+- `PermutateEngine` is intentionally simple — it's a for-loop with a best-tracker and a counter. Its value is the `Strategy<U>` unification, not algorithmic sophistication.
+- Observer hook naming for iterations: `on_generation_start(iteration)` and `on_generation_end(stats)` with `GenerationStats` populated with iteration count and best fitness. Downstream observer users get per-iteration stats without new hooks.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 49-unified-strategy-trait-alternative-strategy-engines*
+*Context gathered: 2026-05-22*

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-DISCUSSION-LOG.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-DISCUSSION-LOG.md
@@ -1,0 +1,120 @@
+# Phase 49: Unified Strategy Trait + Alternative Strategy Engines - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-05-22
+**Phase:** 49-unified-strategy-trait-alternative-strategy-engines
+**Areas discussed:** Strategy<U> trait shape, Observer hook mapping, HillClimbEngine structure, PermutateEngine candidate enumeration
+
+---
+
+## Strategy<U> Trait Shape
+
+### run() return type
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| `()` (side effect only) | Engine stores result internally; user calls `best()` after `run()`. Simplest, dyn-safe. | |
+| `Result<(), GaError>` | Same but propagates engine errors. Consistent with how `Ga::run()` currently signals problems. | ✓ |
+| Associated type per engine | Each engine returns its own result type. NOT dyn-safe — breaks Box<dyn Strategy<U>>. | |
+
+**User's choice:** `Result<(), GaError>`
+
+### best() return type
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| `Option<&U>` (reference, dyn-safe) | Borrow from internal state. Zero-copy. Works for Box<dyn Strategy<U>>. | ✓ |
+| `Option<U>` (clone, dyn-safe) | Owned clone. Simpler caller ergonomics but heavier. | |
+| `U` (panics if not run yet) | Forces engines to have dummy state before run(). Risky. | |
+
+**User's choice:** `Option<&U>`
+
+### with_observer() placement
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| On individual engine structs only | Observer wired at build time before boxing. Trait stays minimal. | ✓ |
+| On the Strategy<U> trait | Allows `strategy.with_observer(obs)` after boxing. Complicates dyn safety. | |
+
+**User's choice:** On individual engine structs only (concrete types)
+
+---
+
+## Observer Hook Mapping
+
+### Which hooks fire in HillClimb/Permutate
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| `on_generation_start + on_new_best + on_generation_end` (reuse GA hooks) | Each iteration is a "generation". on_new_best fires on acceptance. on_run_start/on_run_end bracket. | ✓ |
+| Subset only: on_run_start, on_new_best, on_run_end | Only lifecycle hooks with clear non-GA meaning. Less per-step visibility. | |
+| New engine-specific hooks on GaObserver | Expands GaObserver contract — forces all existing observers to update. | |
+
+**User's choice:** Reuse GA hooks — each iteration mapped as a generation.
+
+### PermutateEngine gate overflow signal
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| `log::warn!` macro | Uses existing `target = "ga_events"` logging pattern from ga.rs. Zero API surface. | ✓ |
+| `on_stagnation` hook | Semantically imperfect reuse of existing infrastructure. | |
+| Return `GaError::PermutationGateExceeded` from `run()` | Non-fatal error treatment — user decides how to handle. | |
+
+**User's choice:** `log::warn!(target = "ga_events", ...)` — existing pattern, no new API.
+
+---
+
+## HillClimbEngine Structure
+
+### Single struct vs two structs
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| One struct with `HillClimbMode` enum field | Shares run(), neighbor_fn, observer wiring, stopping logic. Mode only changes neighbor selection. | ✓ |
+| Two separate structs | Clearer type distinction but duplicates neighbor_fn storage, observer wiring, stopping logic. | |
+
+**User's choice:** Single `HillClimbEngine<U>` with `mode: HillClimbMode` field.
+
+### neighbor_fn storage type
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| `Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>` | Consistent with observer storage. Clonable. | ✓ |
+| `Box<dyn Fn(&U) -> Vec<U>>` | Simpler, non-clonable. Less consistent with Arc pattern. | |
+
+**User's choice:** `Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>`
+
+---
+
+## PermutateEngine Candidate Enumeration
+
+### How candidates are generated
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| User provides `Vec<U>` at build time | Engine iterates lazily (.iter()), tracks running best. Decoupled from chromosome internals. | ✓ |
+| Engine generates permutations from starting chromosome + alphabet | Tightly coupled — only works for permutation chromosomes. | |
+| User provides a closure `Fn(usize) -> Option<U>` | Lazy, no Vec allocation. But callable state needs Box/Arc storage. | |
+
+**User's choice:** `Vec<U>` at build time, engine iterates lazily.
+
+### Materialization strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Evaluate lazily — iterate and compare, no full materialization | Only current best kept in memory. Gate counts iterations. | ✓ |
+| Materialize into Vec<U> first, then evaluate | Holds all candidates in memory. Defeats safety gate purpose. | |
+
+**User's choice:** Lazy iteration — evaluate one at a time.
+
+---
+
+## Claude's Discretion
+
+None — all areas had clear user preferences.
+
+## Deferred Ideas
+
+None — discussion stayed within phase scope.

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-RESEARCH.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-RESEARCH.md
@@ -1,0 +1,784 @@
+# Phase 49: Unified Strategy Trait + Alternative Strategy Engines — Research
+
+**Researched:** 2026-05-22
+**Domain:** Rust trait design, engine implementation patterns, observer wiring
+**Confidence:** HIGH
+
+---
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+- **D-01:** `Strategy<U>` trait exposes exactly `fn run(&mut self) -> Result<(), GaError>` and `fn best(&self) -> Option<&U>`. No builder methods on the trait — stays minimal and dyn-safe.
+- **D-02:** `with_observer()` lives only on individual engine structs (concrete types), not on the trait. Observer wiring happens before boxing.
+- **D-03:** The trait must be dyn-safe. Both methods are dyn-safe. No associated types, no generics on methods.
+- **D-04:** Hill-climb observer hooks: `on_run_start`, `on_generation_start(iteration)`, `on_new_best(iteration, best)` (only on improvement), `on_generation_end(stats)`, `on_run_end`. GA-only hooks (`on_selection_complete`, `on_crossover_complete`, `on_mutation_complete`, `on_survivor_selection_complete`, `on_fitness_evaluation_complete`, `on_extension_triggered`, `on_stagnation`) do NOT fire.
+- **D-05:** `PermutateEngine` fires same subset: `on_run_start`, `on_generation_start(candidate_index)`, `on_new_best`, `on_generation_end`, `on_run_end`. Each candidate evaluation is one "generation."
+- **D-06:** Gate overflow uses `log::warn!(target = "ga_events", ...)` and returns `Ok(())`. No observer hook for gate overflow.
+- **D-07:** `HillClimbEngine<U>` has one struct with `mode: HillClimbMode` enum field. `HillClimbMode::Stochastic` accepts first neighbor with higher fitness. `HillClimbMode::SteepestAscent` evaluates all, accepts global best.
+- **D-08:** `neighbor_fn` stored as `Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>`.
+- **D-09:** `PermutateEngine<U>` accepts `Vec<U>` at build time, iterates lazily via `.iter()`.
+- **D-10:** Safety gate is a configurable `usize` field on `PermutateConfiguration` (default 100,000). Evaluates up to the gate, then warns and returns.
+- **D-11:** New engines land in `src/engines/hill_climb/` and `src/engines/permutate/` following `src/engines/de/` pattern. `Strategy<U>` trait lives in `src/traits/strategy.rs`, re-exported from `src/traits.rs`.
+- **D-12:** `Ga<U>` implements `Strategy<U>` as an explicit impl — no changes to `Ga` internals.
+
+### Claude's Discretion
+
+None — all decisions were locked in discussion.
+
+### Deferred Ideas (OUT OF SCOPE)
+
+None — discussion stayed within phase scope.
+
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| STR-01 | `Strategy<U>` trait with `run()` / `best()` enabling `Box<dyn Strategy<U>>` runtime swapping | D-01 through D-03 + dyn-safety analysis below |
+| STR-02 | `HillClimbEngine::Stochastic` — first-improving neighbor, configurable no-improvement limit, `GaObserver` hooks | D-04, D-07, D-08 + observer wiring pattern |
+| STR-03 | `HillClimbEngine::SteepestAscent` — evaluate all neighbors, accept global best, `GaObserver` hooks | D-04, D-07, D-08 |
+| STR-04 | `PermutateEngine` — exhaustive candidate eval up to safety gate, `GaObserver` hooks per candidate | D-05, D-06, D-09, D-10 |
+
+</phase_requirements>
+
+---
+
+## Summary
+
+Phase 49 adds a thin `Strategy<U>` trait that imposes a uniform `run()` / `best()` interface across all engines, enabling runtime algorithm swapping via `Box<dyn Strategy<U>>`. The trait is added to two new engines (`HillClimbEngine<U>` and `PermutateEngine<U>`) and retrofitted onto the existing `Ga<U>`. No existing engine internals change.
+
+Both new engines follow the structural pattern established by `src/engines/de/` (three-file layout: `mod.rs`, `engine.rs`, `configuration.rs`) and wire `GaObserver<U>` exactly as `ga.rs` does (the `notify()` closure pattern). The critical constraint is WASM compatibility: no `Instant::now()` calls, no `par_iter()` in new engines. Both engines iterate sequentially over their work units — hill-climb neighbor lists and permutation candidate slices — so no WASM-specific branching is needed in their hot paths.
+
+The `Ga<U>` impl of `Strategy<U>` is a three-line wrapper: `run()` calls `self.run()` internally (discarding the `&Population<U>` return) and `best()` reads `self.population.best_chromosome_is_set` then returns `Some(&self.population.best_chromosome)` or `None`.
+
+**Primary recommendation:** Follow `de/` layout exactly. Copy the `notify()` helper verbatim from `ga.rs`. Gate any `Instant` usage behind `#[cfg(not(target_arch = "wasm32"))]`. All new test files go under `tests/engines/hill_climb/` and `tests/engines/permutate/`.
+
+---
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| `Strategy<U>` trait definition | `src/traits/strategy.rs` | re-export via `src/traits.rs` + `src/lib.rs` | Traits module owns all public trait contracts |
+| `Ga<U>` Strategy impl | `src/engines/ga.rs` | — | Impl block on the existing struct; no structural change |
+| `HillClimbEngine<U>` struct + loop | `src/engines/hill_climb/engine.rs` | — | Mirror of `de/engine.rs` |
+| `HillClimbConfiguration` | `src/engines/hill_climb/configuration.rs` | — | Mirror of `de/configuration.rs` |
+| `HillClimbMode` enum | `src/engines/hill_climb/configuration.rs` | — | Co-located with config; single-variant branch in engine loop |
+| `PermutateEngine<U>` struct + loop | `src/engines/permutate/engine.rs` | — | Simpler than `de/` — no adaptive state |
+| `PermutateConfiguration` | `src/engines/permutate/configuration.rs` | — | Safety gate + problem_solving |
+| Observer dispatch | Engine struct `notify()` helper | `GaObserver<U>` trait | Zero-overhead when None |
+| Public API surface | `src/lib.rs` | `src/traits.rs` | All new types re-exported at crate root |
+
+---
+
+## Standard Stack
+
+No new external dependencies are introduced by this phase. [VERIFIED: CONTEXT.md / STATE.md]
+
+All packages already in `Cargo.toml` are used as-is:
+
+| Item | Already Present | Purpose in Phase 49 |
+|------|----------------|---------------------|
+| `rand` / `rand_chacha` | Yes | `make_rng()` for stochastic neighbor shuffling |
+| `log` | Yes | `log::warn!(target = "ga_events", ...)` for gate overflow |
+| `std::sync::Arc` | Yes | `neighbor_fn` + `observer` storage |
+
+---
+
+## Package Legitimacy Audit
+
+No new packages are installed in this phase. This section is N/A.
+
+---
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+User code
+   │
+   ├── Box<dyn Strategy<U>>  ←── runtime dispatch
+   │         │
+   │    ┌────┴──────────────────────────────┐
+   │    │                                   │
+   │  Ga<U>::run()            HillClimbEngine<U>::run()
+   │  Ga<U>::best()           HillClimbEngine<U>::best()
+   │    │                           │
+   │  existing GA loop         neighbor_fn(&current) → Vec<U>
+   │    │                           │
+   │    │                    mode branch:
+   │    │                    ├── Stochastic: first-improving
+   │    │                    └── SteepestAscent: global-best
+   │    │                           │
+   │    │                     observer.notify(on_generation_end)
+   │    │
+   │  PermutateEngine<U>::run()
+   │  PermutateEngine<U>::best()
+   │    │
+   │  candidates.iter() (lazy, up to safety gate)
+   │    │
+   │  track running best
+   │    │
+   │  observer.notify(on_generation_end per candidate)
+   │
+GaObserver<U> hooks (subset: run_start, gen_start, new_best, gen_end, run_end)
+```
+
+### Recommended Project Structure
+
+```
+src/engines/
+├── de/                         # existing
+├── hill_climb/
+│   ├── mod.rs                  # pub use re-exports
+│   ├── engine.rs               # HillClimbEngine<U> struct + impl
+│   └── configuration.rs        # HillClimbConfiguration, HillClimbMode
+└── permutate/
+    ├── mod.rs                  # pub use re-exports
+    ├── engine.rs               # PermutateEngine<U> struct + impl
+    └── configuration.rs        # PermutateConfiguration
+
+src/traits/
+├── strategy.rs                 # Strategy<U> trait (NEW)
+└── (existing files unchanged)
+
+tests/engines/
+├── hill_climb/
+│   └── test_hill_climb.rs
+└── permutate/
+    └── test_permutate.rs
+```
+
+### Pattern 1: Strategy Trait Definition
+
+**What:** Minimal dyn-safe trait with exactly two methods.
+**When to use:** Define in `src/traits/strategy.rs`.
+
+```rust
+// Source: CONTEXT.md D-01/D-03 + Rust reference on dyn-safety
+use crate::error::GaError;
+use crate::traits::ChromosomeT;
+
+/// Common interface over all search strategy engines.
+///
+/// Enables runtime algorithm swapping via `Box<dyn Strategy<U>>`.
+/// All implementations must wire `GaObserver` hooks before boxing.
+pub trait Strategy<U: ChromosomeT> {
+    /// Execute the search loop. Mutates internal state.
+    fn run(&mut self) -> Result<(), GaError>;
+
+    /// Returns the best candidate found, or `None` if `run()` has not been called.
+    fn best(&self) -> Option<&U>;
+}
+```
+
+**Dyn-safety analysis:** Both methods are dyn-safe. [VERIFIED: Rust reference] `run(&mut self) -> Result<(), GaError>` — no generics, no `Self` in return position. `best(&self) -> Option<&U>` — `U` is the trait's type parameter, bound at `dyn Strategy<U>` site, not a method-level generic. This is the same dyn-safe pattern used by `GaObserver<U>`.
+
+### Pattern 2: Ga<U> impl of Strategy<U>
+
+**What:** Thin three-line wrapper on the existing `Ga<U>`. No changes to `Ga` internals.
+**When to use:** Add an `impl Strategy<U> for Ga<U>` block in `src/engines/ga.rs`.
+
+Key facts from code inspection:
+- `Ga<U>::run(&mut self)` returns `Result<&Population<U>, GaError>` — the `Strategy` impl discards the reference.
+- `population.best_chromosome` is `pub` on `Population<U>`.
+- `population.best_chromosome_is_set` is `pub(crate)` — accessible inside the crate.
+
+```rust
+// Source: inspected ga.rs lines 1263, population.rs lines 46-47
+impl<U> Strategy<U> for Ga<U>
+where
+    U: LinearChromosome + Send + Sync + 'static + Clone,
+{
+    fn run(&mut self) -> Result<(), GaError> {
+        self.run().map(|_| ())
+    }
+
+    fn best(&self) -> Option<&U> {
+        if self.population.best_chromosome_is_set {
+            Some(&self.population.best_chromosome)
+        } else {
+            None
+        }
+    }
+}
+```
+
+**Bound note:** `Ga<U>::run_with_callback` imposes `U: LinearChromosome + Send + Sync + 'static + Clone + MaybeDeserialize`. The `impl Strategy<U> for Ga<U>` block must carry at minimum `U: LinearChromosome` (the struct-level bound) plus whatever `run_with_callback` requires. Check if `MaybeDeserialize` needs to appear on the impl — if so, import it. [ASSUMED: the exact bound combination compiles without conflict; verify with `cargo check`.]
+
+### Pattern 3: Observer Wiring (copy from ga.rs verbatim)
+
+**What:** `observer: Option<Arc<dyn GaObserver<U> + Send + Sync>>` field + `notify()` helper + `with_observer()` builder. This is the ONLY approved observer pattern — zero overhead when None.
+
+```rust
+// Source: ga.rs lines 278, 859-870
+/// Optional structured lifecycle observer.
+observer: Option<Arc<dyn GaObserver<U> + Send + Sync>>,
+
+/// Attaches a lifecycle observer.
+pub fn with_observer(mut self, observer: Arc<dyn GaObserver<U> + Send + Sync>) -> Self {
+    self.observer = Some(observer);
+    self
+}
+
+/// Dispatches an observer hook. No-op when observer is None.
+#[inline]
+fn notify<F: FnOnce(&dyn GaObserver<U>)>(&self, f: F) {
+    if let Some(ref obs) = self.observer {
+        f(obs.as_ref());
+    }
+}
+```
+
+### Pattern 4: HillClimbEngine Run Loop
+
+**What:** Single struct, two modes, shared loop body with a single branch at neighbor selection.
+
+```rust
+// Source: CONTEXT.md D-07/D-08, derived from de/engine.rs structure
+pub struct HillClimbEngine<U: LinearChromosome> {
+    config: HillClimbConfiguration,
+    neighbor_fn: Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>,
+    current: Option<U>,
+    observer: Option<Arc<dyn GaObserver<U> + Send + Sync>>,
+}
+
+impl<U: LinearChromosome + Clone> HillClimbEngine<U> {
+    pub fn run(&mut self) -> Result<(), GaError> {
+        // Initialize: current must be set before run() or return ConfigurationError
+        let mut current = self.current.take()
+            .ok_or_else(|| GaError::ConfigurationError("no initial solution".into()))?;
+
+        self.notify(|obs| obs.on_run_start());
+
+        let mut no_improvement_count = 0usize;
+        let mut iteration = 0usize;
+        let mut all_stats: Vec<GenerationStats> = Vec::new();
+
+        loop {
+            self.notify(|obs| obs.on_generation_start(iteration));
+
+            let neighbors = (self.neighbor_fn)(&current);
+            let improved = match self.config.mode {
+                HillClimbMode::Stochastic => {
+                    // First-improving: accept first neighbor with higher fitness
+                    neighbors.into_iter().find(|n| self.is_better(n, &current))
+                }
+                HillClimbMode::SteepestAscent => {
+                    // Evaluate all, accept global best only if better than current
+                    neighbors.into_iter()
+                        .filter(|n| self.is_better(n, &current))
+                        .max_by(|a, b| self.cmp_fitness(a, b))
+                }
+            };
+
+            if let Some(next) = improved {
+                self.notify(|obs| obs.on_new_best(iteration, next.clone()));
+                current = next;
+                no_improvement_count = 0;
+            } else {
+                no_improvement_count += 1;
+            }
+
+            let stats = GenerationStats {
+                generation: iteration,
+                best_fitness: current.fitness(),
+                worst_fitness: current.fitness(),
+                avg_fitness: current.fitness(),
+                fitness_std_dev: 0.0,
+                population_size: 1,
+                diversity: 0.0,
+                dynamic_mutation_probability: None,
+            };
+            all_stats.push(stats.clone());
+            self.notify(|obs| obs.on_generation_end(&stats));
+
+            iteration += 1;
+
+            // Stopping: SteepestAscent stops when no improvement found (no_improvement_count >= 1)
+            // Stochastic stops when no_improvement_count >= config.no_improvement_limit
+            if self.should_stop(no_improvement_count) {
+                break;
+            }
+        }
+
+        self.current = Some(current);
+        self.notify(|obs| obs.on_run_end(TerminationCause::GenerationLimitReached, &all_stats));
+        Ok(())
+    }
+}
+```
+
+**WASM note:** `neighbors.into_iter()` / `.iter()` only — never `.par_iter()`. No `Instant::now()`. [VERIFIED: CONTEXT.md]
+
+### Pattern 5: PermutateEngine Run Loop
+
+```rust
+// Source: CONTEXT.md D-09/D-10, derived from de/engine.rs structure
+pub struct PermutateEngine<U: ChromosomeT> {
+    config: PermutateConfiguration,
+    candidates: Vec<U>,
+    best: Option<U>,
+    observer: Option<Arc<dyn GaObserver<U> + Send + Sync>>,
+}
+
+impl<U: ChromosomeT + Clone> PermutateEngine<U> {
+    pub fn run(&mut self) -> Result<(), GaError> {
+        self.notify(|obs| obs.on_run_start());
+
+        let gate = self.config.safety_gate;
+        let mut best: Option<U> = None;
+        let mut all_stats: Vec<GenerationStats> = Vec::new();
+
+        for (idx, candidate) in self.candidates.iter().enumerate() {
+            if idx >= gate {
+                log::warn!(
+                    target = "ga_events",
+                    "PermutateEngine: safety gate of {} reached, stopping evaluation",
+                    gate
+                );
+                break;
+            }
+
+            self.notify(|obs| obs.on_generation_start(idx));
+
+            let is_new_best = match &best {
+                None => true,
+                Some(b) => self.is_better(candidate.fitness(), b.fitness()),
+            };
+
+            if is_new_best {
+                self.notify(|obs| obs.on_new_best(idx, candidate.clone()));
+                best = Some(candidate.clone());
+            }
+
+            let stats = GenerationStats {
+                generation: idx,
+                best_fitness: best.as_ref().map(|b| b.fitness()).unwrap_or(f64::NAN),
+                worst_fitness: candidate.fitness(),
+                avg_fitness: candidate.fitness(),
+                fitness_std_dev: 0.0,
+                population_size: 1,
+                diversity: 0.0,
+                dynamic_mutation_probability: None,
+            };
+            all_stats.push(stats.clone());
+            self.notify(|obs| obs.on_generation_end(&stats));
+        }
+
+        self.best = best;
+        self.notify(|obs| obs.on_run_end(TerminationCause::GenerationLimitReached, &all_stats));
+        Ok(())
+    }
+}
+```
+
+**Design note:** `PermutateEngine` iterates over a pre-built `Vec<U>`. Candidates must have fitness pre-evaluated by the caller before being passed in, OR `PermutateConfiguration` carries a fitness function to evaluate them inside the loop. The CONTEXT.md does not specify this — **the planner must resolve this: does `PermutateEngine` receive pre-evaluated candidates or does it carry a fitness function?** [ASSUMED: candidates are pre-evaluated by caller, consistent with D-09 "user materializes the candidate list". Needs confirmation during planning.]
+
+### Pattern 6: Module Re-exports (mirror de/mod.rs exactly)
+
+```rust
+// src/engines/hill_climb/mod.rs — Source: de/mod.rs pattern
+pub mod configuration;
+pub mod engine;
+
+pub use configuration::{HillClimbConfiguration, HillClimbMode};
+pub use engine::HillClimbEngine;
+```
+
+```rust
+// src/engines/permutate/mod.rs
+pub mod configuration;
+pub mod engine;
+
+pub use configuration::PermutateConfiguration;
+pub use engine::PermutateEngine;
+```
+
+### Pattern 7: lib.rs Registration
+
+```rust
+// Add to src/lib.rs — mirror of existing de/scatter/alps entries
+#[path = "engines/hill_climb/mod.rs"]
+pub mod hill_climb;
+
+#[path = "engines/permutate/mod.rs"]
+pub mod permutate;
+
+// Flat re-exports at crate root
+pub use hill_climb::{HillClimbEngine, HillClimbConfiguration, HillClimbMode};
+pub use permutate::{PermutateEngine, PermutateConfiguration};
+pub use traits::Strategy;
+```
+
+### Pattern 8: Strategy re-export in traits.rs
+
+```rust
+// Add to src/traits.rs
+pub mod strategy;
+pub use strategy::Strategy;
+```
+
+### Anti-Patterns to Avoid
+
+- **Adding builder methods to `Strategy<U>`:** Destroys dyn-safety if any builder returns `Self`. Locked decision D-01.
+- **Calling `par_iter()` in new engines:** WASM mandatory constraint. Use `.iter()` only.
+- **Calling `Instant::now()` unconditionally:** Gate with `#[cfg(not(target_arch = "wasm32"))]` if timing is ever needed.
+- **Putting tests inline with implementation:** Project rule — all tests in `tests/` directory.
+- **Firing GA-only hooks in non-GA engines:** `on_selection_complete`, `on_crossover_complete`, etc. must NOT fire in hill-climb or permutation loops (D-04).
+- **Using `Box<dyn Fn>` instead of `Arc<dyn Fn>` for neighbor_fn:** `Arc` is required for Clone-ability and consistency with observer storage pattern (D-08).
+- **Modifying `Ga<U>` internals:** `impl Strategy<U> for Ga<U>` is purely additive — no field changes, no behavior changes to existing methods (D-12).
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Random neighbor selection order | Custom shuffle | `make_rng()` + iterator ordering | Existing RNG already handles seeding/reproducibility |
+| Observer dispatch boilerplate | Match arms | `notify()` closure pattern from ga.rs | Three lines, zero overhead when None |
+| Fitness comparison (min/max) | Custom logic | `ProblemSolving` enum + `is_better()` helper | Already established in `de/engine.rs`; copy the pattern |
+| Test chromosome types | New struct | `RangeChromosome<f64>` / `Binary` from `tests/engines/de/test_de.rs` | Existing test infra is ready |
+
+**Key insight:** The `is_better()` helper in `de/engine.rs` (lines 237-249) is the canonical `ProblemSolving`-aware comparator. Copy this pattern into both new engines rather than writing ad-hoc comparisons.
+
+---
+
+## Runtime State Inventory
+
+Step 2.5: SKIPPED — this is a greenfield feature addition, not a rename/refactor/migration phase.
+
+---
+
+## Environment Availability
+
+Step 2.6: No external tool dependencies beyond the existing Rust toolchain.
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| `cargo` | build + test | Yes | (project's Rust toolchain) | — |
+| `cargo check --target wasm32-unknown-unknown` | WASM gate | Yes | requires wasm32 target installed | install: `rustup target add wasm32-unknown-unknown` |
+
+**Verify wasm32 target is installed before implementation:**
+```bash
+rustup target list --installed | grep wasm32-unknown-unknown
+```
+
+---
+
+## Common Pitfalls
+
+### Pitfall 1: Ga<U> impl requires extra bounds beyond struct definition
+
+**What goes wrong:** `Ga<U>` struct is bounded by `U: LinearChromosome`. Its `run_with_callback` method adds `U: ... + Clone + MaybeDeserialize`. If the `Strategy<U>` impl for `Ga<U>` calls `run_with_callback`, the impl block must carry those extra bounds or the compiler rejects it.
+
+**Why it happens:** Method-level bounds are not inherited by impl blocks in Rust — each impl block must declare everything it needs.
+
+**How to avoid:** Write the impl block with the full bound set that `run_with_callback` requires. Alternatively, expose a separate internal method that does not require `MaybeDeserialize` if that bound is inconvenient. [ASSUMED: `MaybeDeserialize` is a serde feature gate — verify if it can be excluded when `serde` feature is off.]
+
+**Warning signs:** `error[E0277]: the trait bound ... is not satisfied` when compiling `impl Strategy<U> for Ga<U>`.
+
+### Pitfall 2: `best()` before `run()` returns stale data
+
+**What goes wrong:** `Ga<U>::best()` reads `population.best_chromosome_is_set`. If a user calls `best()` before `run()`, the flag is `false` and `best()` returns `None`. This is correct behavior — but the `HillClimbEngine` and `PermutateEngine` must handle the same pre-run state.
+
+**How to avoid:** Both new engines store `current: Option<U>` / `best: Option<U>` as `None` by default and return `None` from `best()` before `run()` is called. This is consistent and correct.
+
+### Pitfall 3: SteepestAscent stopping condition
+
+**What goes wrong:** `SteepestAscent` stops when the best neighbor is not better than current. If `neighbors` is empty (user's `neighbor_fn` returned `Vec::new()`), the engine must not panic and should treat this as "no improvement."
+
+**Why it happens:** `.max_by()` on an empty iterator returns `None`, which is then treated as "no improvement" — correct behavior if the code checks `Option` properly.
+
+**How to avoid:** The `improved.is_none()` path increments `no_improvement_count` regardless of whether the neighbor list was empty or all-worse. No special case needed, but add a test covering an empty neighbor list.
+
+### Pitfall 4: PermutateEngine candidate fitness not pre-evaluated
+
+**What goes wrong:** If candidates in `Vec<U>` have `NaN` fitness (default state), the `is_better()` comparisons all return `false` (NaN comparisons are always false in IEEE 754), and `best` remains `None` after the run.
+
+**Why it happens:** `ChromosomeT::new()` sets fitness to `NaN` by convention (see `LinearChromosome::reset()`). A caller who builds chromosomes without calling `calculate_fitness()` will silently produce wrong results.
+
+**How to avoid:** Document clearly in `PermutateEngine`'s doc comment that candidates must have fitness set. Optionally, `PermutateConfiguration` can carry an optional fitness function (like `DeConfiguration` carries one) and the engine evaluates if present. **This design choice must be made during planning** — current CONTEXT.md is silent on whether `PermutateEngine` evaluates fitness internally.
+
+### Pitfall 5: `on_run_end` requires `TerminationCause`
+
+**What goes wrong:** `GaObserver::on_run_end` takes `(cause: TerminationCause, all_stats: &[GenerationStats])`. New engines must decide which `TerminationCause` variant to pass. There is no "NoImprovementLimit" variant in the current `TerminationCause` enum.
+
+**Why it happens:** `TerminationCause` was designed for `Ga<U>`. Hill-climb stopping is semantically different (no-improvement threshold or SteepestAscent convergence). Permutation engine stopping is "all candidates evaluated" or "gate reached."
+
+**How to avoid:** Use `TerminationCause::GenerationLimitReached` as the closest semantic match for both new engines. If a new variant (e.g., `NoImprovementLimitReached`) is desired, add it to `GaError` — but this is a non-breaking addition only if `TerminationCause` does not appear in match arms in user code. **The planner should decide: reuse `GenerationLimitReached` or add variants.** [ASSUMED: reuse existing variants to avoid any match-exhaustion breakage for users; this is the least-risk path.]
+
+### Pitfall 6: `mod.rs` required for nested modules with submodules
+
+**What goes wrong:** If `src/engines/hill_climb/` needs any nested submodule in the future, the directory form (`mod.rs`) is required, not the single-file form. Since all existing engine directories use the `mod.rs` pattern, follow the same.
+
+**How to avoid:** Always use `src/engines/hill_climb/mod.rs`, not `src/engines/hill_climb.rs`. This is confirmed by the STATE.md v2.3.0 decision.
+
+---
+
+## Code Examples
+
+### Complete HillClimbConfiguration
+
+```rust
+// Source: CONTEXT.md D-07/D-08/D-10 + de/configuration.rs pattern
+use crate::configuration::ProblemSolving;
+use std::sync::Arc;
+use crate::traits::LinearChromosome;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum HillClimbMode {
+    /// Accept the first neighbor with higher fitness (early exit).
+    Stochastic,
+    /// Evaluate all neighbors; accept the global best if better than current.
+    SteepestAscent,
+}
+
+#[derive(Clone)]
+pub struct HillClimbConfiguration {
+    /// Which mode to use for neighbor selection.
+    pub mode: HillClimbMode,
+    /// Stochastic mode: stop after this many consecutive iterations with no improvement.
+    pub no_improvement_limit: usize,
+    /// Whether to minimize or maximize fitness.
+    pub problem_solving: ProblemSolving,
+}
+
+impl Default for HillClimbConfiguration {
+    fn default() -> Self {
+        Self {
+            mode: HillClimbMode::Stochastic,
+            no_improvement_limit: 100,
+            problem_solving: ProblemSolving::Minimization,
+        }
+    }
+}
+
+impl HillClimbConfiguration {
+    pub fn with_mode(mut self, mode: HillClimbMode) -> Self {
+        self.mode = mode;
+        self
+    }
+    pub fn with_no_improvement_limit(mut self, limit: usize) -> Self {
+        self.no_improvement_limit = limit;
+        self
+    }
+    pub fn with_problem_solving(mut self, ps: ProblemSolving) -> Self {
+        self.problem_solving = ps;
+        self
+    }
+}
+```
+
+### Complete PermutateConfiguration
+
+```rust
+// Source: CONTEXT.md D-10 + de/configuration.rs pattern
+use crate::configuration::ProblemSolving;
+
+#[derive(Debug, Clone)]
+pub struct PermutateConfiguration {
+    /// Maximum number of candidates to evaluate before stopping.
+    pub safety_gate: usize,
+    /// Whether to minimize or maximize fitness.
+    pub problem_solving: ProblemSolving,
+}
+
+impl Default for PermutateConfiguration {
+    fn default() -> Self {
+        Self {
+            safety_gate: 100_000,
+            problem_solving: ProblemSolving::Minimization,
+        }
+    }
+}
+
+impl PermutateConfiguration {
+    pub fn with_safety_gate(mut self, gate: usize) -> Self {
+        self.safety_gate = gate;
+        self
+    }
+    pub fn with_problem_solving(mut self, ps: ProblemSolving) -> Self {
+        self.problem_solving = ps;
+        self
+    }
+}
+```
+
+### `is_better()` helper (copy from de/engine.rs)
+
+```rust
+// Source: de/engine.rs lines 237-249
+fn is_better(&self, candidate: f64, current: f64) -> bool {
+    match self.config.problem_solving {
+        ProblemSolving::Minimization => candidate < current,
+        ProblemSolving::Maximization => candidate > current,
+        ProblemSolving::FixedFitness => {
+            if let Some(t) = self.config.fitness_target {
+                (candidate - t).abs() < (current - t).abs()
+            } else {
+                candidate < current
+            }
+        }
+    }
+}
+```
+
+**Note:** `HillClimbConfiguration` should include `fitness_target: Option<f64>` if `is_better` with `FixedFitness` is needed. `PermutateConfiguration` should also include it. [ASSUMED: add `fitness_target: Option<f64>` to both configs for consistency with `DeConfiguration`.]
+
+---
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| `Reporter<U>` trait for hooks | `GaObserver<U>` with 12 hooks | v3.0.0 (Phase 47) | New engines use `GaObserver` only — `Reporter` is removed |
+| Engine-specific observer sub-traits added to `AllObserver` | Separate per-engine observer sub-traits (not in `AllObserver`) | v2.4.0+ | `HillClimbEngine` uses `GaObserver` directly — no new sub-trait needed |
+
+---
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | `impl Strategy<U> for Ga<U>` can use `GenerationLimitReached` for `on_run_end` without adding new `TerminationCause` variants | Pitfall 5 / Pattern 2 | Low — adding a variant is non-breaking but requires a decision; reusing existing is safe |
+| A2 | `PermutateEngine` candidates are pre-evaluated (fitness set by caller before passing `Vec<U>`) | Pattern 5 / Pitfall 4 | MEDIUM — if wrong, `best()` silently returns `None` or the wrong candidate; planner must resolve |
+| A3 | `MaybeDeserialize` bound on `Ga::run_with_callback` is feature-gated via `serde` and does not appear on non-serde builds, allowing a simpler `impl Strategy<U> for Ga<U>` bound | Pitfall 1 / Pattern 2 | MEDIUM — if wrong, the Strategy impl requires importing `MaybeDeserialize` or using a cfg gate |
+| A4 | Both new configs include `fitness_target: Option<f64>` for `FixedFitness` parity with `DeConfiguration` | Code Examples | Low — omitting it is also valid; planner can decide |
+
+**If this table is empty:** N/A — assumptions are documented above.
+
+---
+
+## Open Questions
+
+1. **Does `PermutateEngine` evaluate fitness internally or require pre-evaluated candidates?**
+   - What we know: D-09 says "user materializes the candidate list"; the context is silent on fitness evaluation.
+   - What's unclear: If candidates are built via chromosome constructors (default NaN fitness), the engine silently produces wrong output.
+   - Recommendation: Add an optional `fitness_fn: Option<Arc<FitnessFn<U::Gene>>>` to `PermutateConfiguration` (consistent with `DeConfiguration`). If present, evaluate each candidate inside the loop; if absent, trust the caller's pre-evaluated fitness. Document this in `PermutateEngine`'s doc comment.
+
+2. **Should `TerminationCause` gain new variants for hill-climb/permutation termination reasons?**
+   - What we know: Existing variants are `GenerationLimitReached`, `FitnessTargetReached`, `StagnationReached`, `ConvergenceReached`, `TimeLimitReached`, `CallbackRequested`, `NotTerminated`.
+   - What's unclear: Whether a `NoImprovementLimitReached` variant adds user value or is premature.
+   - Recommendation: Reuse `GenerationLimitReached` for both new engines in v3.0.0. Adding variants in a future phase is non-breaking.
+
+3. **Should `HillClimbEngine` require an initial solution at build time or via a separate method?**
+   - What we know: D-07/D-08 define `HillClimbEngine<U>` with `mode`, `neighbor_fn`, but do not specify how the initial solution is provided.
+   - Recommendation: Accept the initial solution as a required parameter of `HillClimbEngine::new()` — mirrors how `PermutateEngine::new()` takes `candidates: Vec<U>`.
+
+---
+
+## Validation Architecture
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | Rust built-in test (`cargo test`) |
+| Config file | `Cargo.toml` (workspace-level) |
+| Quick run command | `cargo test --test test_hill_climb -- --nocapture` |
+| Full suite command | `cargo test && cargo test --features serde && cargo clippy` |
+
+### Phase Requirements to Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| STR-01 | `Box<dyn Strategy<U>>` compiles and dispatches to `Ga`, `HillClimbEngine`, `PermutateEngine` | integration | `cargo test --test test_strategy_trait` | No — Wave 0 |
+| STR-01 | `Strategy<U>` is dyn-safe (compilation test) | compile | `cargo build` | No — Wave 0 |
+| STR-02 | `HillClimbEngine::Stochastic` finds improving solution on a simple landscape | integration | `cargo test --test test_hill_climb stochastic` | No — Wave 0 |
+| STR-02 | Stochastic stops after `no_improvement_limit` consecutive non-improving iterations | unit | `cargo test --test test_hill_climb stochastic_stops` | No — Wave 0 |
+| STR-02 | Observer hooks fire in correct order during stochastic run | integration | `cargo test --test test_hill_climb observer_hooks` | No — Wave 0 |
+| STR-03 | `SteepestAscent` converges on a simple unimodal landscape | integration | `cargo test --test test_hill_climb steepest_ascent` | No — Wave 0 |
+| STR-03 | `SteepestAscent` stops when best neighbor is not better than current | unit | `cargo test --test test_hill_climb steepest_stops` | No — Wave 0 |
+| STR-04 | `PermutateEngine` evaluates all candidates and returns the best | integration | `cargo test --test test_permutate basic` | No — Wave 0 |
+| STR-04 | Safety gate triggers `log::warn` and stops early when exceeded | unit | `cargo test --test test_permutate gate_overflow` | No — Wave 0 |
+| STR-04 | Observer hooks fire per candidate | integration | `cargo test --test test_permutate observer_hooks` | No — Wave 0 |
+
+### Sampling Rate
+
+- **Per task commit:** `cargo test && cargo clippy`
+- **Per wave merge:** `cargo test && cargo test --features serde && cargo clippy && cargo check --target wasm32-unknown-unknown`
+- **Phase gate:** Full suite green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+
+- `tests/engines/hill_climb/test_hill_climb.rs` — covers STR-02, STR-03
+- `tests/engines/permutate/test_permutate.rs` — covers STR-04
+- `tests/engines/test_strategy_trait.rs` — covers STR-01 (dyn dispatch + compilation)
+
+*(If any of the three engine directories are created without a `mod.rs` test module entry, the test runner will not pick up the files automatically — add mod declarations to `tests/engines/` integration test entry points.)*
+
+---
+
+## Security Domain
+
+This phase introduces no authentication, session management, input validation from external sources, cryptography, or network I/O. The only user-provided input is:
+- `neighbor_fn: Fn(&U) -> Vec<U>` — trusted user closure, no sanitization needed.
+- `candidates: Vec<U>` — owned by the caller, no injection surface.
+
+Security domain: NOT APPLICABLE.
+
+---
+
+## Project Constraints (from CLAUDE.md)
+
+These directives are mandatory and must be honored by every task in the plan:
+
+| Directive | Impact on Phase 49 |
+|-----------|-------------------|
+| WASM mandatory — no `Instant::now()` unconditionally | New engines must not call `Instant::now()`. Gate with `#[cfg(not(target_arch = "wasm32"))]` if timing is ever added. |
+| WASM mandatory — no `par_iter()` unconditionally | `HillClimbEngine` iterates neighbor lists with `.iter()`. `PermutateEngine` iterates candidates with `.iter()`. |
+| Tests in `tests/` directory only — never inline | All tests for new engines go under `tests/engines/hill_climb/` and `tests/engines/permutate/`. |
+| No breaking changes by default | `impl Strategy<U> for Ga<U>` adds a new impl block — purely additive, non-breaking. |
+| `log!` macros use `target = "ga_events"` | Gate overflow warn: `log::warn!(target = "ga_events", ...)`. |
+| Branch from milestone branch, not main | Feature work goes on `feat/<issue>-<description>` from `milestone/v3.0.0`. |
+| `cargo check --target wasm32-unknown-unknown` before considering a feature complete | Run at end of every wave. |
+| Observer hooks must be preserved | New engines wire the approved subset of `GaObserver<U>` hooks (D-04/D-05). |
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+
+- `src/engines/ga.rs` lines 278, 859-870 — observer field, `with_observer()`, `notify()` pattern [inspected directly]
+- `src/engines/ga.rs` lines 1263-1269 — `Ga::run()` exact signature (`Result<&Population<U>, GaError>`) [inspected directly]
+- `src/engines/de/engine.rs` — `find_best()`, `is_better()`, `reached_target()` helpers; struct layout [inspected directly]
+- `src/engines/de/configuration.rs` — builder pattern reference [inspected directly]
+- `src/engines/de/mod.rs` — module re-export pattern [inspected directly]
+- `src/observe/observer/mod.rs` — `GaObserver<U>` all 12 hooks, `on_run_end` signature [inspected directly]
+- `src/traits/strategy.rs` — does not exist yet; defined by this phase
+- `src/error.rs` — `GaError` enum variants (all reusable; `ConfigurationError(String)` covers missing initial solution) [inspected directly]
+- `src/stats.rs` — `GenerationStats` struct (all fields; `from_fitness_values` constructor) [inspected directly]
+- `src/population.rs` lines 46-47 — `best_chromosome: U` (pub), `best_chromosome_is_set: bool` (pub(crate)) [inspected directly]
+- `src/traits/linear_chromosome.rs` — `LinearChromosome` supertrait, required by new engines [inspected directly]
+- `src/traits.rs` — current re-exports, insertion point for `Strategy<U>` [inspected directly]
+- `src/lib.rs` — `#[path]` pattern for engine registration, insertion points [inspected directly]
+- `.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-CONTEXT.md` — all locked decisions [inspected directly]
+
+### Secondary (MEDIUM confidence)
+
+- `tests/engines/de/test_de.rs` — test structure reference for new engine tests [inspected directly]
+
+### Tertiary (LOW confidence)
+
+None — all findings verified against source code.
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+
+- Standard stack: HIGH — no new dependencies; all existing crates verified in source
+- Architecture: HIGH — all patterns read directly from source files, not inferred
+- Pitfalls: HIGH (Pitfall 1-3, 6) / MEDIUM (Pitfall 4-5) — NaN fitness and TerminationCause choices are design questions, not bugs
+
+**Research date:** 2026-05-22
+**Valid until:** 2026-06-22 (stable domain — 30-day window)

--- a/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-VERIFICATION.md
+++ b/.planning/phases/49-unified-strategy-trait-alternative-strategy-engines/49-VERIFICATION.md
@@ -1,0 +1,66 @@
+---
+phase: 49-unified-strategy-trait-alternative-strategy-engines
+verified: 2026-05-22T20:30:00Z
+status: passed
+score: 4/4
+overrides_applied: 0
+---
+
+# Phase 49: Unified Strategy Trait + Alternative Strategy Engines — Verification Report
+
+**Phase Goal:** Users can swap between GA, hill-climbing, and exhaustive permutation search at runtime through a single `Strategy<U>` trait, and can use `Box<dyn Strategy<U>>` to select algorithms without rewriting application code.
+**Verified:** 2026-05-22
+**Status:** PASSED
+**Re-verification:** No — initial verification
+
+---
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | User can write `let strategy: Box<dyn Strategy<U>> = Box::new(ga)` and call `.run()` / `.best()` identically regardless of concrete type (`Ga<U>`, `HillClimbEngine<U>`, `PermutateEngine<U>`) | VERIFIED | `tests/engines/test_strategy_trait.rs`: `test_strategy_box_dyn_compiles`, `test_box_dyn_strategy_hill_climb_compiles`, `test_box_dyn_strategy_permutate_compiles`, `test_runtime_strategy_swap` — all pass. `genetic_algorithms::Strategy` re-exported from crate root. |
+| 2 | User can run stochastic hill climbing via `HillClimbEngine` with a neighbor function and no-improvement limit; `GaObserver` hooks fire per iteration | VERIFIED | `tests/engines/hill_climb/test_hill_climb.rs`: `test_stochastic_finds_improvement`, `test_stochastic_stops_on_no_improvement_limit`, `test_stochastic_observer_hooks_order` — all pass. Observer hook sequence verified: run_start → gen_start → new_best → gen_end → run_end; GA-only hooks absent. |
+| 3 | User can run steepest-ascent hill climbing with all neighbors evaluated per step; only global best accepted; engine stops on first non-improving step | VERIFIED | `tests/engines/hill_climb/test_hill_climb.rs`: `test_steepest_ascent_converges`, `test_steepest_ascent_stops_on_no_improvement`, `test_steepest_ascent_empty_neighbor_list` — all pass. Empty neighbor list handled without panic. |
+| 4 | User can run `PermutateEngine` over a small search space; if candidate count exceeds `safety_gate`, engine emits warning and returns best-so-far (no panic); `GaObserver` hooks fire per candidate | VERIFIED | `tests/engines/permutate/test_permutate.rs`: `test_permutate_finds_best_candidate`, `test_permutate_maximization`, `test_permutate_safety_gate_triggers`, `test_permutate_observer_hooks_per_candidate`, `test_permutate_best_before_run_returns_none`, `test_permutate_fitness_target_early_stop` — all pass. |
+
+**Score:** 4/4 truths verified
+
+---
+
+## Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `src/traits/strategy.rs` | Dyn-safe `Strategy<U>` trait with `run()` and `best()` | VERIFIED | Created. Two methods, U-bounded on ChromosomeT, no method-level generics, no associated types. |
+| `src/engines/ga.rs` | `impl Strategy<U> for Ga<U>` | VERIFIED | Additive impl block at end of file. Delegates `run()` via fully-qualified `Ga::run(self)`, reads `best_chromosome_is_set` for `best()`. |
+| `src/engines/hill_climb/` | `HillClimbEngine`, `HillClimbConfiguration`, `HillClimbMode` | VERIFIED | `configuration.rs` + `engine.rs` + `mod.rs` created. Both Stochastic and SteepestAscent modes implemented. No `par_iter()`, no `Instant::now()`. |
+| `src/engines/permutate/` | `PermutateEngine`, `PermutateConfiguration` | VERIFIED | `configuration.rs` + `engine.rs` + `mod.rs` created. Safety gate + log::warn. Bounded on `ChromosomeT` (not `LinearChromosome`). No `par_iter()`. |
+| `src/lib.rs` re-exports | `Strategy`, `HillClimbEngine/Configuration/Mode`, `PermutateEngine/Configuration` at crate root | VERIFIED | `pub use traits::Strategy;`, `pub use hill_climb::{...};`, `pub use permutate::{...};` all present. |
+| `tests/engines/test_strategy_trait.rs` | 4 dyn-dispatch tests (STR-01) | VERIFIED | 4 tests pass. |
+| `tests/engines/hill_climb/test_hill_climb.rs` | 6 HillClimb tests (STR-02, STR-03) | VERIFIED | 6 tests pass. |
+| `tests/engines/permutate/test_permutate.rs` | 6 PermutateEngine tests (STR-04) | VERIFIED | 6 tests pass. |
+
+---
+
+## CI Quality Gates
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| `cargo build` | PASS | Zero errors |
+| `cargo clippy` | PASS | Zero warnings |
+| `cargo check --target wasm32-unknown-unknown` | PASS | No `par_iter()` or `Instant::now()` in new files |
+| `cargo test --test test_engines -- test_strategy test_hill_climb test_permutate` | PASS | 16/16 new tests passing |
+
+---
+
+## Requirements Coverage
+
+| Requirement | Status |
+|-------------|--------|
+| STR-01 — `Box<dyn Strategy<U>>` polymorphic dispatch | VERIFIED |
+| STR-02 — Stochastic hill climbing with observer hooks | VERIFIED |
+| STR-03 — Steepest-ascent hill climbing with convergence stop | VERIFIED |
+| STR-04 — `PermutateEngine` with safety gate and observer hooks | VERIFIED |

--- a/src/engines/ga.rs
+++ b/src/engines/ga.rs
@@ -150,7 +150,7 @@ use crate::{
     traits::{
         ConfigurationT, CrossoverConfig, ElitismConfig, ExtensionConfig, GeneT,
         LinearChromosome, LocalSearchConfig, LocalSearchOperator, MutationConfig, NichingConfig,
-        OperatorCompat, SelectionConfig, StoppingConfig,
+        OperatorCompat, SelectionConfig, StoppingConfig, Strategy,
     },
 };
 use rand::Rng;
@@ -2783,5 +2783,32 @@ fn reinsert_elite<U: LinearChromosome>(
     // Overwrite the k worst slots with the elite individuals.
     for (i, elite_individual) in elite.into_iter().take(k).enumerate() {
         chromosomes[i] = elite_individual;
+    }
+}
+
+impl<U> Strategy<U> for Ga<U>
+where
+    U: LinearChromosome
+        + Send
+        + Sync
+        + 'static
+        + Clone
+        + Debug
+        + mutation::ValueMutable
+        + MaybeSerialize
+        + MaybeDeserialize
+        + OperatorCompat,
+    U::Gene: 'static + Debug,
+{
+    fn run(&mut self) -> Result<(), GaError> {
+        Ga::run(self).map(|_| ())
+    }
+
+    fn best(&self) -> Option<&U> {
+        if self.population.best_chromosome_is_set {
+            Some(&self.population.best_chromosome)
+        } else {
+            None
+        }
     }
 }

--- a/src/engines/hill_climb/configuration.rs
+++ b/src/engines/hill_climb/configuration.rs
@@ -1,0 +1,62 @@
+//! Configuration types for the Hill-climbing engine.
+
+use crate::configuration::ProblemSolving;
+
+/// Search mode used by [`HillClimbEngine`](super::engine::HillClimbEngine).
+#[derive(Debug, Clone, PartialEq)]
+pub enum HillClimbMode {
+    /// Accept the first neighbor with higher fitness; early exit from neighbor scan.
+    Stochastic,
+    /// Evaluate all neighbors; accept only the global best among them.
+    SteepestAscent,
+}
+
+/// Configuration for a [`HillClimbEngine`](super::engine::HillClimbEngine) run.
+#[derive(Clone)]
+pub struct HillClimbConfiguration {
+    /// Hill-climbing search mode.
+    pub mode: HillClimbMode,
+    /// Number of consecutive iterations without improvement before stopping.
+    pub no_improvement_limit: usize,
+    /// Whether to minimise or maximise fitness.
+    pub problem_solving: ProblemSolving,
+    /// Optional fitness target — engine stops early when reached.
+    pub fitness_target: Option<f64>,
+}
+
+impl Default for HillClimbConfiguration {
+    fn default() -> Self {
+        Self {
+            mode: HillClimbMode::Stochastic,
+            no_improvement_limit: 100,
+            problem_solving: ProblemSolving::Minimization,
+            fitness_target: None,
+        }
+    }
+}
+
+impl HillClimbConfiguration {
+    /// Builder: set the search mode.
+    pub fn with_mode(mut self, mode: HillClimbMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Builder: set the no-improvement iteration limit.
+    pub fn with_no_improvement_limit(mut self, limit: usize) -> Self {
+        self.no_improvement_limit = limit;
+        self
+    }
+
+    /// Builder: set problem solving direction.
+    pub fn with_problem_solving(mut self, ps: ProblemSolving) -> Self {
+        self.problem_solving = ps;
+        self
+    }
+
+    /// Builder: set fitness target for early stopping.
+    pub fn with_fitness_target(mut self, t: f64) -> Self {
+        self.fitness_target = Some(t);
+        self
+    }
+}

--- a/src/engines/hill_climb/engine.rs
+++ b/src/engines/hill_climb/engine.rs
@@ -1,0 +1,182 @@
+//! Hill-climbing engine implementation.
+
+use std::sync::Arc;
+
+use crate::configuration::ProblemSolving;
+use crate::error::GaError;
+use crate::ga::TerminationCause;
+use crate::observer::GaObserver;
+use crate::stats::GenerationStats;
+use crate::traits::{LinearChromosome, Strategy};
+use super::configuration::{HillClimbConfiguration, HillClimbMode};
+
+/// Type alias for the neighbor-generation function stored inside [`HillClimbEngine`].
+type NeighborFn<U> = Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>;
+
+/// Hill-climbing search engine.
+///
+/// Performs local search from an initial solution by iteratively evaluating
+/// neighbors. Supports two modes:
+///
+/// - [`HillClimbMode::Stochastic`] — accept the first improving neighbor (fast).
+/// - [`HillClimbMode::SteepestAscent`] — evaluate all neighbors and accept the
+///   best (more thorough, higher per-iteration cost).
+///
+/// Implements [`Strategy<U>`] for runtime swapping with other engines.
+pub struct HillClimbEngine<U: LinearChromosome> {
+    config: HillClimbConfiguration,
+    neighbor_fn: NeighborFn<U>,
+    current: Option<U>,
+    observer: Option<Arc<dyn GaObserver<U> + Send + Sync>>,
+}
+
+impl<U: LinearChromosome + Clone> HillClimbEngine<U> {
+    /// Create a new `HillClimbEngine` from the given configuration and initial solution.
+    ///
+    /// `neighbor_fn` must produce the neighborhood of any candidate solution.
+    pub fn new(
+        config: HillClimbConfiguration,
+        initial: U,
+        neighbor_fn: impl Fn(&U) -> Vec<U> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            config,
+            current: Some(initial),
+            neighbor_fn: Arc::new(neighbor_fn),
+            observer: None,
+        }
+    }
+
+    /// Attach a lifecycle observer.
+    pub fn with_observer(mut self, observer: Arc<dyn GaObserver<U> + Send + Sync>) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    #[inline]
+    fn notify<F: FnOnce(&dyn GaObserver<U>)>(&self, f: F) {
+        if let Some(ref obs) = self.observer {
+            f(obs.as_ref());
+        }
+    }
+
+    fn is_better(&self, candidate: f64, current: f64) -> bool {
+        match self.config.problem_solving {
+            ProblemSolving::Minimization => candidate < current,
+            ProblemSolving::Maximization => candidate > current,
+            ProblemSolving::FixedFitness => {
+                if let Some(t) = self.config.fitness_target {
+                    (candidate - t).abs() < (current - t).abs()
+                } else {
+                    candidate < current
+                }
+            }
+        }
+    }
+
+    /// Execute the hill-climbing search loop.
+    ///
+    /// Returns `Ok(())` on normal termination. The best candidate is available
+    /// via [`HillClimbEngine::best`] after this call.
+    pub fn run(&mut self) -> Result<(), GaError> {
+        let mut current = self.current.take().ok_or_else(|| {
+            GaError::ConfigurationError(
+                "HillClimbEngine: no initial solution provided".to_string(),
+            )
+        })?;
+
+        self.notify(|obs| obs.on_run_start());
+
+        let mut no_improvement_count = 0usize;
+        let mut iteration = 0usize;
+        let mut all_stats: Vec<GenerationStats> =
+            Vec::with_capacity(self.config.no_improvement_limit);
+
+        loop {
+            self.notify(|obs| obs.on_generation_start(iteration));
+
+            let neighbors = (self.neighbor_fn)(&current);
+
+            let best_neighbor = match self.config.mode {
+                HillClimbMode::Stochastic => neighbors
+                    .into_iter()
+                    .find(|n| self.is_better(n.fitness(), current.fitness())),
+                HillClimbMode::SteepestAscent => {
+                    let current_fitness = current.fitness();
+                    let is_better_fn = |a: &U, b: &U| -> std::cmp::Ordering {
+                        if self.is_better(a.fitness(), b.fitness()) {
+                            std::cmp::Ordering::Greater
+                        } else {
+                            std::cmp::Ordering::Less
+                        }
+                    };
+                    neighbors
+                        .into_iter()
+                        .filter(|n| self.is_better(n.fitness(), current_fitness))
+                        .max_by(is_better_fn)
+                }
+            };
+
+            if let Some(next) = best_neighbor {
+                let next_clone = next.clone();
+                self.notify(|obs| obs.on_new_best(iteration, next_clone));
+                current = next;
+                no_improvement_count = 0;
+            } else {
+                no_improvement_count += 1;
+            }
+
+            let stats = GenerationStats {
+                generation: iteration,
+                best_fitness: current.fitness(),
+                worst_fitness: current.fitness(),
+                avg_fitness: current.fitness(),
+                fitness_std_dev: 0.0,
+                population_size: 1,
+                diversity: 0.0,
+                dynamic_mutation_probability: None,
+            };
+            self.notify(|obs| obs.on_generation_end(&stats));
+            all_stats.push(stats);
+
+            iteration += 1;
+
+            // Early stop on fitness target.
+            if let Some(target) = self.config.fitness_target {
+                if self.is_better(current.fitness(), target) {
+                    break;
+                }
+            }
+
+            // No-improvement stopping criterion.
+            let limit = match self.config.mode {
+                HillClimbMode::Stochastic => self.config.no_improvement_limit,
+                HillClimbMode::SteepestAscent => 1,
+            };
+            if no_improvement_count >= limit {
+                break;
+            }
+        }
+
+        self.current = Some(current);
+        self.notify(|obs| obs.on_run_end(TerminationCause::GenerationLimitReached, &all_stats));
+
+        Ok(())
+    }
+
+    /// Returns a reference to the best (current) solution, or `None` if
+    /// [`HillClimbEngine::run`] has not been called.
+    pub fn best(&self) -> Option<&U> {
+        self.current.as_ref()
+    }
+}
+
+impl<U: LinearChromosome + Clone> Strategy<U> for HillClimbEngine<U> {
+    fn run(&mut self) -> Result<(), GaError> {
+        HillClimbEngine::run(self)
+    }
+
+    fn best(&self) -> Option<&U> {
+        HillClimbEngine::best(self)
+    }
+}

--- a/src/engines/hill_climb/mod.rs
+++ b/src/engines/hill_climb/mod.rs
@@ -1,0 +1,10 @@
+//! Hill-climbing engine.
+//!
+//! Provides `HillClimbEngine<U>` with `Stochastic` and `SteepestAscent` modes,
+//! observer wiring, and `Strategy<U>` implementation for runtime algorithm swapping.
+
+pub mod configuration;
+pub mod engine;
+
+pub use configuration::{HillClimbConfiguration, HillClimbMode};
+pub use engine::HillClimbEngine;

--- a/src/engines/permutate/configuration.rs
+++ b/src/engines/permutate/configuration.rs
@@ -1,0 +1,45 @@
+//! Configuration types for the Permutate engine.
+
+use crate::configuration::ProblemSolving;
+
+/// Configuration for `PermutateEngine`. Candidates must have fitness pre-evaluated before being
+/// passed to the engine — `chromosome.fitness()` is called directly, not a fitness function.
+#[derive(Debug, Clone)]
+pub struct PermutateConfiguration {
+    /// Maximum number of candidates to evaluate before stopping.
+    pub safety_gate: usize,
+    /// Whether to minimise or maximise fitness.
+    pub problem_solving: ProblemSolving,
+    /// Optional fitness target — engine stops early when reached.
+    pub fitness_target: Option<f64>,
+}
+
+impl Default for PermutateConfiguration {
+    fn default() -> Self {
+        Self {
+            safety_gate: 100_000,
+            problem_solving: ProblemSolving::Minimization,
+            fitness_target: None,
+        }
+    }
+}
+
+impl PermutateConfiguration {
+    /// Builder: set the safety gate (maximum candidates evaluated).
+    pub fn with_safety_gate(mut self, gate: usize) -> Self {
+        self.safety_gate = gate;
+        self
+    }
+
+    /// Builder: set problem solving direction.
+    pub fn with_problem_solving(mut self, ps: ProblemSolving) -> Self {
+        self.problem_solving = ps;
+        self
+    }
+
+    /// Builder: set fitness target for early stopping.
+    pub fn with_fitness_target(mut self, t: f64) -> Self {
+        self.fitness_target = Some(t);
+        self
+    }
+}

--- a/src/engines/permutate/engine.rs
+++ b/src/engines/permutate/engine.rs
@@ -1,0 +1,150 @@
+//! `PermutateEngine` — exhaustive evaluation of a user-supplied candidate set.
+
+use std::sync::Arc;
+
+use crate::configuration::ProblemSolving;
+use crate::error::GaError;
+use crate::ga::TerminationCause;
+use crate::observer::GaObserver;
+use crate::stats::GenerationStats;
+use crate::traits::{ChromosomeT, Strategy};
+use super::configuration::PermutateConfiguration;
+
+/// Exhaustive permutation search engine.
+///
+/// Iterates over a user-supplied candidate set in order, tracking the best
+/// candidate found so far. Implements [`Strategy<U>`] for runtime swapping
+/// with other engines via `Box<dyn Strategy<U>>`.
+///
+/// Candidates must have fitness pre-evaluated before being passed to the engine —
+/// `chromosome.fitness()` is called directly, not a fitness function.
+pub struct PermutateEngine<U: ChromosomeT> {
+    config: PermutateConfiguration,
+    candidates: Vec<U>,
+    best: Option<U>,
+    observer: Option<Arc<dyn GaObserver<U> + Send + Sync>>,
+}
+
+impl<U: ChromosomeT + Clone> PermutateEngine<U> {
+    /// Construct a new `PermutateEngine`.
+    ///
+    /// * `config` — algorithm parameters.
+    /// * `candidates` — pre-evaluated candidate set. `chromosome.fitness()` is
+    ///   read directly; no fitness function is applied.
+    pub fn new(config: PermutateConfiguration, candidates: Vec<U>) -> Self {
+        Self {
+            config,
+            candidates,
+            best: None,
+            observer: None,
+        }
+    }
+
+    /// Attach a lifecycle observer.
+    pub fn with_observer(mut self, observer: Arc<dyn GaObserver<U> + Send + Sync>) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    #[inline]
+    fn notify<F: FnOnce(&dyn GaObserver<U>)>(&self, f: F) {
+        if let Some(ref obs) = self.observer {
+            f(obs.as_ref());
+        }
+    }
+
+    fn is_better(&self, candidate: f64, current: f64) -> bool {
+        match self.config.problem_solving {
+            ProblemSolving::Minimization => candidate < current,
+            ProblemSolving::Maximization => candidate > current,
+            ProblemSolving::FixedFitness => {
+                if let Some(t) = self.config.fitness_target {
+                    (candidate - t).abs() < (current - t).abs()
+                } else {
+                    candidate < current
+                }
+            }
+        }
+    }
+
+    /// Execute the permutation search loop.
+    ///
+    /// Returns `Ok(())` on normal termination. The best candidate is available
+    /// via [`PermutateEngine::best`] after this call.
+    pub fn run(&mut self) -> Result<(), GaError> {
+        self.notify(|obs| obs.on_run_start());
+
+        let gate = self.config.safety_gate;
+        let mut best: Option<U> = None;
+        let mut all_stats: Vec<GenerationStats> =
+            Vec::with_capacity(self.candidates.len().min(gate));
+
+        for (idx, candidate) in self.candidates.iter().enumerate() {
+            // Safety gate: stop if too many candidates evaluated.
+            if idx >= gate {
+                log::warn!(
+                    target: "ga_events",
+                    "PermutateEngine: safety gate of {} reached, stopping after {} candidates",
+                    gate,
+                    idx
+                );
+                break;
+            }
+
+            self.notify(|obs| obs.on_generation_start(idx));
+
+            let is_new_best = match &best {
+                None => true,
+                Some(b) => self.is_better(candidate.fitness(), b.fitness()),
+            };
+
+            if is_new_best {
+                let candidate_clone = candidate.clone();
+                self.notify(|obs| obs.on_new_best(idx, candidate_clone));
+                best = Some(candidate.clone());
+            }
+
+            let best_fit = best.as_ref().map(|b| b.fitness()).unwrap_or(f64::NAN);
+            let stats = GenerationStats {
+                generation: idx,
+                best_fitness: best_fit,
+                worst_fitness: candidate.fitness(),
+                avg_fitness: candidate.fitness(),
+                fitness_std_dev: 0.0,
+                population_size: 1,
+                diversity: 0.0,
+                dynamic_mutation_probability: None,
+            };
+            self.notify(|obs| obs.on_generation_end(&stats));
+            all_stats.push(stats);
+
+            // Early stop on fitness target.
+            if let Some(target) = self.config.fitness_target {
+                if is_new_best && self.is_better(candidate.fitness(), target) {
+                    break;
+                }
+            }
+        }
+
+        self.best = best;
+        self.notify(|obs| obs.on_run_end(TerminationCause::GenerationLimitReached, &all_stats));
+
+        Ok(())
+    }
+
+    /// Returns a reference to the best candidate found, or `None` if
+    /// [`PermutateEngine::run`] has not been called.
+    pub fn best(&self) -> Option<&U> {
+        self.best.as_ref()
+    }
+}
+
+impl<U: ChromosomeT + Clone> Strategy<U> for PermutateEngine<U> {
+    fn run(&mut self) -> Result<(), GaError> {
+        PermutateEngine::run(self)
+    }
+
+    fn best(&self) -> Option<&U> {
+        PermutateEngine::best(self)
+    }
+}

--- a/src/engines/permutate/mod.rs
+++ b/src/engines/permutate/mod.rs
@@ -1,0 +1,11 @@
+//! Permutation engine.
+//!
+//! Provides `PermutateEngine<U>` for exhaustive evaluation of a user-supplied
+//! candidate set with a configurable safety gate. Implements `Strategy<U>` for
+//! runtime algorithm swapping via `Box<dyn Strategy<U>>`.
+
+pub mod configuration;
+pub mod engine;
+
+pub use configuration::PermutateConfiguration;
+pub use engine::PermutateEngine;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,8 @@ pub mod alps;
 pub mod cellular;
 #[path = "engines/de/mod.rs"]
 pub mod de;
+#[path = "engines/hill_climb/mod.rs"]
+pub mod hill_climb;
 #[path = "engines/scatter/mod.rs"]
 pub mod scatter;
 #[path = "engines/island/mod.rs"]
@@ -329,6 +331,7 @@ pub use aos::{AosState, AosStrategy};
 pub use traits::LinearChromosome;
 pub use traits::OperatorCompat;
 pub use traits::Strategy;
+pub use hill_climb::{HillClimbEngine, HillClimbConfiguration, HillClimbMode};
 pub use chromosomes::ChromosomeLength;
 pub use chromosomes::UniqueChromosome;
 pub use genotypes::UniqueGenotype;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,8 @@ pub mod cellular;
 pub mod de;
 #[path = "engines/hill_climb/mod.rs"]
 pub mod hill_climb;
+#[path = "engines/permutate/mod.rs"]
+pub mod permutate;
 #[path = "engines/scatter/mod.rs"]
 pub mod scatter;
 #[path = "engines/island/mod.rs"]
@@ -332,6 +334,7 @@ pub use traits::LinearChromosome;
 pub use traits::OperatorCompat;
 pub use traits::Strategy;
 pub use hill_climb::{HillClimbEngine, HillClimbConfiguration, HillClimbMode};
+pub use permutate::{PermutateEngine, PermutateConfiguration};
 pub use chromosomes::ChromosomeLength;
 pub use chromosomes::UniqueChromosome;
 pub use genotypes::UniqueGenotype;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,7 @@ pub use hall_of_fame::{DistanceMetric, HallOfFame, HallOfFameConfig};
 pub use aos::{AosState, AosStrategy};
 pub use traits::LinearChromosome;
 pub use traits::OperatorCompat;
+pub use traits::Strategy;
 pub use chromosomes::ChromosomeLength;
 pub use chromosomes::UniqueChromosome;
 pub use genotypes::UniqueGenotype;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -28,6 +28,7 @@
 //! | [`CrossoverOperator`] | Trait for custom crossover implementations |
 //! | [`MutationOperator`] | Trait for custom mutation implementations |
 //! | [`SurvivorOperator`] | Trait for custom survivor selection implementations |
+//! | [`Strategy`] | Common interface for runtime algorithm swapping via `Box<dyn Strategy<U>>` |
 //!
 //! # When to use
 //! Implement these traits when creating custom chromosome types, gene types,
@@ -42,6 +43,8 @@ pub mod group_aware;
 pub mod linear_chromosome;
 pub mod operator_compat;
 pub mod operators;
+pub mod strategy;
+pub use strategy::Strategy;
 
 pub use chromosome::ChromosomeT;
 pub use common::{initialize_chromosomes, initialize_chromosomes_par, FitnessFn, InitializationFn};

--- a/src/traits/strategy.rs
+++ b/src/traits/strategy.rs
@@ -1,0 +1,13 @@
+//! Common interface over all search strategy engines.
+//! Enables runtime algorithm swapping via `Box<dyn Strategy<U>>`.
+
+use crate::error::GaError;
+use crate::traits::ChromosomeT;
+
+/// Common interface over all search strategy engines. Enables runtime algorithm swapping via `Box<dyn Strategy<U>>`.
+pub trait Strategy<U: ChromosomeT> {
+    /// Execute the search loop. Mutates internal state.
+    fn run(&mut self) -> Result<(), GaError>;
+    /// Returns the best candidate found, or `None` if `run()` has not been called.
+    fn best(&self) -> Option<&U>;
+}

--- a/tests/engines/hill_climb/test_hill_climb.rs
+++ b/tests/engines/hill_climb/test_hill_climb.rs
@@ -1,0 +1,260 @@
+//! Integration tests for HillClimbEngine — STR-02, STR-03.
+
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
+
+use genetic_algorithms::chromosomes::Range as RangeChromosome;
+use genetic_algorithms::ga::TerminationCause;
+use genetic_algorithms::genotypes::Range as RangeGene;
+use genetic_algorithms::stats::GenerationStats;
+use genetic_algorithms::traits::{ChromosomeT, LinearChromosome};
+use genetic_algorithms::{GaObserver, HillClimbConfiguration, HillClimbEngine, HillClimbMode};
+
+// ─── Observer ────────────────────────────────────────────────────────────────
+
+struct RecordingObserver {
+    events: Mutex<Vec<String>>,
+}
+
+impl RecordingObserver {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            events: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn events(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl<U: ChromosomeT> GaObserver<U> for RecordingObserver {
+    fn on_run_start(&self) {
+        self.events.lock().unwrap().push("run_start".to_string());
+    }
+
+    fn on_generation_start(&self, _g: usize) {
+        self.events.lock().unwrap().push("gen_start".to_string());
+    }
+
+    fn on_new_best(&self, _g: usize, _best: U) {
+        self.events.lock().unwrap().push("new_best".to_string());
+    }
+
+    fn on_generation_end(&self, _stats: &GenerationStats) {
+        self.events.lock().unwrap().push("gen_end".to_string());
+    }
+
+    fn on_run_end(&self, _cause: TerminationCause, _all_stats: &[GenerationStats]) {
+        self.events.lock().unwrap().push("run_end".to_string());
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn make_neighbor_fn(
+    step: f64,
+) -> impl Fn(&RangeChromosome<f64>) -> Vec<RangeChromosome<f64>> {
+    move |c| {
+        let current_val = c.dna()[0].value();
+        let lo = -100.0;
+        let hi = 100.0;
+        let val_down = current_val - step;
+        let val_up = current_val + step;
+
+        let mut n_down = <RangeChromosome<f64>>::default();
+        n_down.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], val_down)]));
+        n_down.set_fitness(val_down.abs());
+
+        let mut n_up = <RangeChromosome<f64>>::default();
+        n_up.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], val_up)]));
+        n_up.set_fitness(val_up.abs());
+
+        vec![n_down, n_up]
+    }
+}
+
+fn make_initial(value: f64) -> RangeChromosome<f64> {
+    let gene = RangeGene::new(0, vec![(-100.0, 100.0)], value);
+    let mut c = <RangeChromosome<f64>>::default();
+    c.set_dna(Cow::Owned(vec![gene]));
+    c.set_fitness(value.abs());
+    c
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_stochastic_finds_improvement() {
+    let initial = make_initial(5.0);
+    let initial_fitness = initial.fitness();
+
+    let config = HillClimbConfiguration::default()
+        .with_mode(HillClimbMode::Stochastic)
+        .with_no_improvement_limit(10);
+
+    let mut engine = HillClimbEngine::new(config, initial, make_neighbor_fn(0.1));
+    engine.run().expect("run must succeed");
+
+    let best = engine.best().expect("best must be Some after run");
+    assert!(
+        best.fitness() < initial_fitness,
+        "stochastic hill climb should improve from {} to something less",
+        initial_fitness
+    );
+}
+
+#[test]
+fn test_stochastic_stops_on_no_improvement_limit() {
+    // Neighbor fn always returns a chromosome with fitness worse than current
+    let initial = make_initial(5.0);
+
+    let config = HillClimbConfiguration::default()
+        .with_mode(HillClimbMode::Stochastic)
+        .with_no_improvement_limit(3);
+
+    let mut engine = HillClimbEngine::new(config, initial, |c| {
+        let val = c.dna()[0].value();
+        let lo = -100.0;
+        let hi = 100.0;
+        // Return a neighbor with strictly worse fitness (higher abs value)
+        let worse_val = val + 10.0;
+        let mut n = <RangeChromosome<f64>>::default();
+        n.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], worse_val)]));
+        n.set_fitness(worse_val.abs());
+        vec![n]
+    });
+
+    engine.run().expect("engine must terminate without panic");
+    assert!(
+        engine.best().is_some(),
+        "best() must return Some even when no improvement occurs"
+    );
+}
+
+#[test]
+fn test_stochastic_observer_hooks_order() {
+    let observer = RecordingObserver::new();
+    let initial = make_initial(2.0);
+
+    let config = HillClimbConfiguration::default()
+        .with_mode(HillClimbMode::Stochastic)
+        .with_no_improvement_limit(1);
+
+    let mut engine =
+        HillClimbEngine::new(config, initial, make_neighbor_fn(0.1))
+            .with_observer(observer.clone() as Arc<dyn GaObserver<RangeChromosome<f64>> + Send + Sync>);
+
+    engine.run().expect("run must succeed");
+
+    let events = observer.events();
+
+    // run_start must be first
+    assert_eq!(events[0], "run_start", "first event must be run_start");
+
+    // run_end must be last
+    assert_eq!(
+        events.last().unwrap(),
+        "run_end",
+        "last event must be run_end"
+    );
+
+    // gen_start must appear before gen_end
+    let gen_start_pos = events.iter().position(|e| e == "gen_start").expect("gen_start missing");
+    let gen_end_pos = events.iter().position(|e| e == "gen_end").expect("gen_end missing");
+    assert!(gen_start_pos < gen_end_pos, "gen_start must precede gen_end");
+
+    // GA-specific hooks must NOT appear
+    for event in &events {
+        assert_ne!(event, "selection_complete", "selection_complete must not fire");
+        assert_ne!(event, "crossover_complete", "crossover_complete must not fire");
+        assert_ne!(event, "mutation_complete", "mutation_complete must not fire");
+    }
+}
+
+#[test]
+fn test_steepest_ascent_converges() {
+    let initial = make_initial(5.0);
+    let initial_fitness = initial.fitness(); // 5.0
+
+    let config = HillClimbConfiguration::default()
+        .with_mode(HillClimbMode::SteepestAscent)
+        .with_no_improvement_limit(1);
+
+    // Neighbor fn returns 5 neighbors at various step sizes
+    let mut engine = HillClimbEngine::new(config, initial, |c| {
+        let val = c.dna()[0].value();
+        let lo = -100.0;
+        let hi = 100.0;
+        let steps = [0.1, -0.1, 0.2, -0.2, 0.5];
+        steps
+            .iter()
+            .map(|&s| {
+                let nv = val + s;
+                let mut n = <RangeChromosome<f64>>::default();
+                n.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], nv)]));
+                n.set_fitness(nv.abs());
+                n
+            })
+            .collect()
+    });
+
+    engine.run().expect("run must succeed");
+
+    let best = engine.best().expect("best must be Some after run");
+    assert!(
+        best.fitness() < initial_fitness,
+        "SteepestAscent should improve fitness: got {} >= {}",
+        best.fitness(),
+        initial_fitness
+    );
+}
+
+#[test]
+fn test_steepest_ascent_stops_on_no_improvement() {
+    let initial = make_initial(5.0);
+
+    let config = HillClimbConfiguration::default()
+        .with_mode(HillClimbMode::SteepestAscent)
+        .with_no_improvement_limit(1);
+
+    // Always return neighbors worse than current
+    let mut engine = HillClimbEngine::new(config, initial, |c| {
+        let val = c.dna()[0].value();
+        let lo = -100.0;
+        let hi = 100.0;
+        let worse_val = val + 1.0;
+        let mut n = <RangeChromosome<f64>>::default();
+        n.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], worse_val)]));
+        n.set_fitness(worse_val.abs());
+        vec![n]
+    });
+
+    engine.run().expect("engine must terminate without panic");
+    assert!(
+        engine.best().is_some(),
+        "best() must be Some even when no improvement found"
+    );
+}
+
+#[test]
+fn test_steepest_ascent_empty_neighbor_list() {
+    let initial = make_initial(3.0);
+
+    let config = HillClimbConfiguration::default()
+        .with_mode(HillClimbMode::SteepestAscent)
+        .with_no_improvement_limit(1);
+
+    // Neighbor fn returns empty list — engine must not panic
+    let mut engine = HillClimbEngine::new(config, initial, |_c| vec![]);
+
+    engine.run().expect("empty neighbors must not panic");
+
+    let best = engine.best();
+    assert!(best.is_some(), "best() must return Some (the initial chromosome)");
+    assert_eq!(
+        best.unwrap().fitness(),
+        3.0,
+        "best should be the initial chromosome with fitness 3.0"
+    );
+}

--- a/tests/engines/permutate/test_permutate.rs
+++ b/tests/engines/permutate/test_permutate.rs
@@ -1,0 +1,210 @@
+//! Integration tests for PermutateEngine — STR-04.
+
+use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
+
+use genetic_algorithms::chromosomes::Range as RangeChromosome;
+use genetic_algorithms::configuration::ProblemSolving;
+use genetic_algorithms::ga::TerminationCause;
+use genetic_algorithms::genotypes::Range as RangeGene;
+use genetic_algorithms::stats::GenerationStats;
+use genetic_algorithms::traits::{ChromosomeT, LinearChromosome};
+use genetic_algorithms::{GaObserver, PermutateConfiguration, PermutateEngine};
+
+// ─── Observer ────────────────────────────────────────────────────────────────
+
+struct RecordingObserver {
+    events: Mutex<Vec<String>>,
+}
+
+impl RecordingObserver {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            events: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn events(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl<U: ChromosomeT> GaObserver<U> for RecordingObserver {
+    fn on_run_start(&self) {
+        self.events.lock().unwrap().push("run_start".to_string());
+    }
+
+    fn on_generation_start(&self, _g: usize) {
+        self.events.lock().unwrap().push("gen_start".to_string());
+    }
+
+    fn on_new_best(&self, _g: usize, _best: U) {
+        self.events.lock().unwrap().push("new_best".to_string());
+    }
+
+    fn on_generation_end(&self, _stats: &GenerationStats) {
+        self.events.lock().unwrap().push("gen_end".to_string());
+    }
+
+    fn on_run_end(&self, _cause: TerminationCause, _all_stats: &[GenerationStats]) {
+        self.events.lock().unwrap().push("run_end".to_string());
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn make_candidate(value: f64) -> RangeChromosome<f64> {
+    let gene = RangeGene::new(0, vec![(-10.0, 10.0)], value);
+    let mut c = <RangeChromosome<f64>>::default();
+    c.set_dna(Cow::Owned(vec![gene]));
+    c.set_fitness(value); // fitness IS the value directly
+    c
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_permutate_finds_best_candidate() {
+    let candidates = vec![
+        make_candidate(3.0),
+        make_candidate(1.0),
+        make_candidate(4.0),
+        make_candidate(1.5),
+        make_candidate(2.0),
+    ];
+    let config = PermutateConfiguration::default()
+        .with_safety_gate(1000);
+
+    let mut engine = PermutateEngine::new(config, candidates);
+    engine.run().expect("run must succeed");
+
+    let best = engine.best().expect("best must be Some after run");
+    assert_eq!(
+        best.fitness(),
+        1.0,
+        "minimization should select the candidate with fitness 1.0"
+    );
+}
+
+#[test]
+fn test_permutate_maximization() {
+    let candidates = vec![
+        make_candidate(1.0),
+        make_candidate(5.0),
+        make_candidate(2.0),
+    ];
+    let config = PermutateConfiguration::default()
+        .with_problem_solving(ProblemSolving::Maximization);
+
+    let mut engine = PermutateEngine::new(config, candidates);
+    engine.run().expect("run must succeed");
+
+    let best = engine.best().expect("best must be Some after run");
+    assert_eq!(
+        best.fitness(),
+        5.0,
+        "maximization should select the candidate with fitness 5.0"
+    );
+}
+
+#[test]
+fn test_permutate_safety_gate_triggers() {
+    let candidates: Vec<RangeChromosome<f64>> = (0..10)
+        .map(|i| make_candidate(i as f64))
+        .collect();
+
+    let config = PermutateConfiguration::default()
+        .with_safety_gate(3);
+
+    let mut engine = PermutateEngine::new(config, candidates);
+    let result = engine.run();
+
+    assert!(result.is_ok(), "run must return Ok even when safety gate triggers");
+    assert!(engine.best().is_some(), "best must be Some even when gate triggers");
+}
+
+#[test]
+fn test_permutate_observer_hooks_per_candidate() {
+    let observer = RecordingObserver::new();
+    let candidates = vec![
+        make_candidate(3.0),
+        make_candidate(1.0),
+        make_candidate(2.0),
+    ];
+    let config = PermutateConfiguration::default();
+
+    let mut engine = PermutateEngine::new(config, candidates)
+        .with_observer(observer.clone() as Arc<dyn GaObserver<RangeChromosome<f64>> + Send + Sync>);
+
+    engine.run().expect("run must succeed");
+
+    let events = observer.events();
+
+    let run_start_count = events.iter().filter(|e| *e == "run_start").count();
+    assert_eq!(run_start_count, 1, "run_start must fire exactly once");
+
+    let gen_start_count = events.iter().filter(|e| *e == "gen_start").count();
+    assert_eq!(
+        gen_start_count,
+        3,
+        "gen_start must fire once per candidate (3 candidates)"
+    );
+
+    let run_end_count = events.iter().filter(|e| *e == "run_end").count();
+    assert_eq!(run_end_count, 1, "run_end must fire exactly once");
+
+    let new_best_count = events.iter().filter(|e| *e == "new_best").count();
+    assert!(new_best_count >= 1, "new_best must fire at least once");
+
+    for event in &events {
+        assert_ne!(
+            event, "selection_complete",
+            "selection_complete must not fire in PermutateEngine"
+        );
+    }
+}
+
+#[test]
+fn test_permutate_best_before_run_returns_none() {
+    let candidates = vec![make_candidate(1.0), make_candidate(2.0)];
+    let config = PermutateConfiguration::default();
+
+    let engine = PermutateEngine::new(config, candidates);
+
+    // Do NOT call run()
+    assert!(
+        engine.best().is_none(),
+        "best() must return None before run() is called"
+    );
+}
+
+#[test]
+fn test_permutate_fitness_target_early_stop() {
+    let candidates: Vec<RangeChromosome<f64>> = vec![
+        make_candidate(5.0),
+        make_candidate(4.0),
+        make_candidate(3.0),
+        make_candidate(2.0),
+        make_candidate(1.0),
+        make_candidate(0.5),
+        make_candidate(0.1),
+        make_candidate(0.0),
+        make_candidate(-0.1),
+        make_candidate(-0.2),
+    ];
+
+    let config = PermutateConfiguration::default()
+        .with_fitness_target(1.5);
+
+    let mut engine = PermutateEngine::new(config, candidates);
+    let result = engine.run();
+
+    assert!(result.is_ok(), "run must succeed with fitness target");
+
+    let best = engine.best().expect("best must be Some after run");
+    assert!(
+        best.fitness() <= 1.5,
+        "early stop: best fitness {} should be <= 1.5",
+        best.fitness()
+    );
+}

--- a/tests/engines/test_strategy_trait.rs
+++ b/tests/engines/test_strategy_trait.rs
@@ -1,0 +1,157 @@
+//! Integration tests for the Strategy<U> trait — STR-01.
+
+use std::borrow::Cow;
+
+use genetic_algorithms::chromosomes::Range as RangeChromosome;
+use genetic_algorithms::configuration::ProblemSolving;
+use genetic_algorithms::ga::Ga;
+use genetic_algorithms::genotypes::Range as RangeGene;
+use genetic_algorithms::operations::{Crossover, Mutation, Selection, Survivor};
+use genetic_algorithms::population::Population;
+use genetic_algorithms::traits::{
+    ChromosomeT, ConfigurationT, CrossoverConfig, LinearChromosome, MutationConfig,
+    SelectionConfig, StoppingConfig,
+};
+use genetic_algorithms::{HillClimbConfiguration, HillClimbEngine, HillClimbMode};
+use genetic_algorithms::{PermutateConfiguration, PermutateEngine};
+use genetic_algorithms::Strategy;
+
+fn sphere(dna: &[RangeGene<f64>]) -> f64 {
+    dna.iter().map(|g| g.value() * g.value()).sum()
+}
+
+fn make_candidate(value: f64) -> RangeChromosome<f64> {
+    let gene = RangeGene::new(0, vec![(-10.0, 10.0)], value);
+    let mut c = <RangeChromosome<f64> as Default>::default();
+    c.set_dna(Cow::Owned(vec![gene]));
+    c.set_fitness(value * value);
+    c
+}
+
+fn make_ga_population(n: usize) -> Vec<RangeChromosome<f64>> {
+    (0..n)
+        .map(|i| {
+            let val = (i as f64) - (n as f64 / 2.0);
+            let gene = RangeGene::new(0, vec![(-10.0, 10.0)], val);
+            let mut c = <RangeChromosome<f64> as Default>::default();
+            c.set_dna(Cow::Owned(vec![gene.clone(), gene.clone()]));
+            c
+        })
+        .collect()
+}
+
+#[test]
+fn test_strategy_box_dyn_compiles() {
+    let chromosomes = make_ga_population(5);
+    let population = Population::new(chromosomes);
+
+    let mut ga: Box<dyn Strategy<RangeChromosome<f64>>> = Box::new(
+        Ga::new()
+            .with_problem_solving(ProblemSolving::Minimization)
+            .with_selection_method(Selection::Random)
+            .with_crossover_method(Crossover::SinglePoint)
+            .with_mutation_method(Mutation::Gaussian)
+            .with_survivor_method(Survivor::Fitness)
+            .with_max_generations(10)
+            .with_population(population)
+            .with_fitness_fn(sphere),
+    );
+
+    let result = ga.run();
+    assert!(result.is_ok(), "Ga via Box<dyn Strategy> must succeed: {:?}", result.err());
+    assert!(ga.best().is_some(), "best() must return Some after run");
+}
+
+#[test]
+fn test_box_dyn_strategy_hill_climb_compiles() {
+    let initial = make_candidate(5.0);
+    let config = HillClimbConfiguration::default();
+
+    let mut engine: Box<dyn Strategy<RangeChromosome<f64>>> = Box::new(
+        HillClimbEngine::new(config, initial, |c| {
+            let val = c.dna()[0].value();
+            let lo = -10.0;
+            let hi = 10.0;
+            let mut n1 = <RangeChromosome<f64>>::default();
+            n1.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], val - 0.1)]));
+            n1.set_fitness((val - 0.1) * (val - 0.1));
+            let mut n2 = <RangeChromosome<f64>>::default();
+            n2.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], val + 0.1)]));
+            n2.set_fitness((val + 0.1) * (val + 0.1));
+            vec![n1, n2]
+        }),
+    );
+
+    let result = engine.run();
+    assert!(result.is_ok(), "HillClimbEngine via Box<dyn Strategy> must succeed: {:?}", result.err());
+    assert!(engine.best().is_some(), "best() must return Some after run");
+}
+
+#[test]
+fn test_box_dyn_strategy_permutate_compiles() {
+    let candidates = vec![
+        make_candidate(3.0),
+        make_candidate(1.0),
+        make_candidate(2.0),
+    ];
+    let config = PermutateConfiguration::default();
+
+    let mut engine: Box<dyn Strategy<RangeChromosome<f64>>> =
+        Box::new(PermutateEngine::new(config, candidates));
+
+    let result = engine.run();
+    assert!(result.is_ok(), "PermutateEngine via Box<dyn Strategy> must succeed: {:?}", result.err());
+    let best = engine.best();
+    assert!(best.is_some(), "best() must return Some after run");
+    assert_eq!(
+        best.unwrap().fitness(),
+        1.0,
+        "minimization should pick the candidate with fitness 1.0"
+    );
+}
+
+#[test]
+fn test_runtime_strategy_swap() {
+    // Build a GA
+    let chromosomes = make_ga_population(5);
+    let population = Population::new(chromosomes);
+    let ga: Box<dyn Strategy<RangeChromosome<f64>>> = Box::new(
+        Ga::new()
+            .with_problem_solving(ProblemSolving::Minimization)
+            .with_selection_method(Selection::Random)
+            .with_crossover_method(Crossover::SinglePoint)
+            .with_mutation_method(Mutation::Gaussian)
+            .with_survivor_method(Survivor::Fitness)
+            .with_max_generations(5)
+            .with_population(population)
+            .with_fitness_fn(sphere),
+    );
+
+    // Build a HillClimbEngine
+    let initial = make_candidate(3.0);
+    let hill_climb: Box<dyn Strategy<RangeChromosome<f64>>> = Box::new(
+        HillClimbEngine::new(
+            HillClimbConfiguration::default()
+                .with_mode(HillClimbMode::Stochastic)
+                .with_no_improvement_limit(5),
+            initial,
+            |c| {
+                let val = c.dna()[0].value();
+                let lo = -10.0;
+                let hi = 10.0;
+                let mut n1 = <RangeChromosome<f64>>::default();
+                n1.set_dna(Cow::Owned(vec![RangeGene::new(0, vec![(lo, hi)], val - 0.1)]));
+                n1.set_fitness((val - 0.1) * (val - 0.1));
+                vec![n1]
+            },
+        ),
+    );
+
+    let mut strategies: Vec<Box<dyn Strategy<RangeChromosome<f64>>>> = vec![ga, hill_climb];
+
+    for strategy in strategies.iter_mut() {
+        let result = strategy.run();
+        assert!(result.is_ok(), "strategy.run() must succeed: {:?}", result.err());
+        assert!(strategy.best().is_some(), "best() must return Some after run");
+    }
+}

--- a/tests/test_engines.rs
+++ b/tests/test_engines.rs
@@ -60,4 +60,11 @@ mod engines {
     mod aos {
         mod test_aos;
     }
+    mod test_strategy_trait;
+    mod hill_climb {
+        mod test_hill_climb;
+    }
+    mod permutate {
+        mod test_permutate;
+    }
 }


### PR DESCRIPTION
## Summary

**Phase 49: Unified Strategy Trait + Alternative Strategy Engines**
**Goal:** Users can swap between GA, hill-climbing, and exhaustive permutation search at runtime through a single `Strategy<U>` trait, and can use `Box<dyn Strategy<U>>` to select algorithms without rewriting application code.
**Status:** Verified ✓

This phase adds a minimal two-method `Strategy<U>` dyn-safe trait and two new search engines (`HillClimbEngine` and `PermutateEngine`) that all implement it alongside the existing `Ga<U>`. Users can now hold any engine in a `Box<dyn Strategy<U>>` and swap algorithms at runtime without changing calling code.

---

## Changes

### Plan 49-01: Strategy Trait + Ga<U> Impl + Re-exports

Added `Strategy<U>` dyn-safe trait enabling runtime algorithm swapping via `Box<dyn Strategy<U>>`.

**Key files:**
- `src/traits/strategy.rs` — created: dyn-safe `Strategy<U>` trait (`run()` + `best()`)
- `src/engines/ga.rs` — modified: additive `impl Strategy<U> for Ga<U>` block at end of file
- `src/traits.rs` — modified: `pub mod strategy; pub use strategy::Strategy;`
- `src/lib.rs` — modified: `pub use traits::Strategy;`

### Plan 49-02: HillClimbEngine + HillClimbConfiguration

`HillClimbEngine<U>` with `Stochastic` and `SteepestAscent` modes, observer wiring, and `Strategy<U>` impl.

**Key files:**
- `src/engines/hill_climb/configuration.rs` — created: `HillClimbMode` enum + `HillClimbConfiguration` struct
- `src/engines/hill_climb/engine.rs` — created: full engine with both modes, `notify()` helper, `is_better()`, `Strategy<U>` impl
- `src/engines/hill_climb/mod.rs` — created: re-exports mirroring DE module structure
- `src/lib.rs` — modified: `#[path]` entry + flat re-exports

### Plan 49-03: PermutateEngine + PermutateConfiguration

`PermutateEngine<U>` for exhaustive candidate evaluation with a configurable safety gate and `Strategy<U>` impl.

**Key files:**
- `src/engines/permutate/configuration.rs` — created: `PermutateConfiguration` struct (safety_gate, problem_solving, fitness_target)
- `src/engines/permutate/engine.rs` — created: `ChromosomeT`-bounded engine, safety gate with `log::warn!`, observer wiring, `Strategy<U>` impl
- `src/engines/permutate/mod.rs` — created: re-exports
- `src/lib.rs` — modified: `#[path]` entry + flat re-exports

### Plan 49-04: Integration Tests

16 integration tests covering all four STR requirements.

**Key files:**
- `tests/test_engines.rs` — modified: 3 new module declarations
- `tests/engines/test_strategy_trait.rs` — created: 4 dyn-dispatch tests (STR-01)
- `tests/engines/hill_climb/test_hill_climb.rs` — created: 6 hill-climb tests (STR-02, STR-03)
- `tests/engines/permutate/test_permutate.rs` — created: 6 permutate tests (STR-04)

---

## Requirements Addressed

| Requirement | Description | Status |
|-------------|-------------|--------|
| STR-01 | `Box<dyn Strategy<U>>` polymorphic dispatch across all three engines | ✓ |
| STR-02 | Stochastic hill climbing with `neighbor_fn`, no-improvement limit, observer hooks | ✓ |
| STR-03 | Steepest-ascent hill climbing — all neighbors evaluated, best accepted per step, stops on first non-improving step | ✓ |
| STR-04 | `PermutateEngine` over pre-evaluated candidate set, safety gate with warn (not panic), observer hooks per candidate | ✓ |

---

## Verification

- [x] `cargo build` — PASS
- [x] `cargo clippy` — PASS (0 warnings)
- [x] `cargo check --target wasm32-unknown-unknown` — PASS (no `par_iter()` or `Instant::now()` in new files)
- [x] `cargo test --test test_engines -- test_strategy test_hill_climb test_permutate` — 16/16 PASS
- [x] Full test suite (`cargo test`) — PASS (all existing tests continue to pass)
- [x] VERIFICATION.md: status `passed`, score 4/4

---

## Key Decisions

- **`Strategy<U>` dyn-safety**: `U` is the trait's type parameter, not a method-level generic. Both `run()` (takes `&mut self`) and `best()` (takes `&self`) are dyn-safe with no associated types.
- **`Ga<U>` fully-qualified call**: `impl Strategy<U> for Ga<U>::run()` uses `Ga::run(self)` to avoid unconditional recursion (method resolution would otherwise pick the `Strategy` impl itself).
- **`NeighborFn<U>` type alias**: Added to satisfy clippy `type_complexity` on the `Arc<dyn Fn(&U) -> Vec<U> + Send + Sync>` field in `HillClimbEngine`.
- **`PermutateEngine` bounded on `ChromosomeT`** (not `LinearChromosome`): it only calls `.fitness()`, never accesses DNA — wider compatibility across chromosome types.
- **Safety gate as `log::warn!`, not `Err`**: Partial results are returned rather than an error, matching the "best-effort exhaustive search" intent.
- **SteepestAscent no-improvement limit = 1**: After one full neighbor scan with no improvement, the algorithm has reached a strict local optimum and stops.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
