### PR TITLE
feat(51): multi-parent crossover (UNDX/SPX/PCX) + self-adaptive mutation

### DIFF
--- a/.planning/phases/51-multi-parent-crossover-self-adaptive-mutation/51-CONTEXT.md
+++ b/.planning/phases/51-multi-parent-crossover-self-adaptive-mutation/51-CONTEXT.md
@@ -1,0 +1,24 @@
+---
+phase: 51-multi-parent-crossover-self-adaptive-mutation
+status: planned
+branch: feat/51-multi-parent-crossover-self-adaptive-mutation
+target: milestone/v3.0.0
+depends_on: [47]
+---
+
+## Goal
+
+Extend the real-valued chromosome operator set with multi-parent crossover and self-adaptive mutation.
+
+Crossover operators (require `RealValued` marker trait; binary/permutation chromosomes return `GaError`):
+- `Crossover::Undx { num_parents }` — Unimodal Normal Distribution Crossover
+- `Crossover::Spx { num_parents }` — Simplex Crossover
+- `Crossover::Pcx { num_parents }` — Parent-Centric Crossover
+
+Self-adaptive mutation:
+- `SelfAdaptive: ChromosomeT` — per-chromosome sigma vector co-evolves alongside the solution
+- `Mutation::SelfAdaptiveGaussian` — log-normal sigma update (strategy parameter evolution)
+
+## Requirements
+
+CRS-02, CRS-03, CRS-04, MUT-05, TRAITS-02


### PR DESCRIPTION
## Phase 51 — Multi-Parent Crossover + Self-Adaptive Mutation

Extends real-valued chromosome operators with multi-parent crossover and co-evolving sigma vectors.

**Multi-parent crossover** (require `RealValued` marker trait; binary/permutation chromosomes return `GaError` at build time)
- `Crossover::Undx { num_parents }` — Unimodal Normal Distribution Crossover
- `Crossover::Spx { num_parents }` — Simplex Crossover
- `Crossover::Pcx { num_parents }` — Parent-Centric Crossover

**Self-adaptive mutation**
- `SelfAdaptive: ChromosomeT` — per-chromosome sigma vector stored alongside the solution
- `Mutation::SelfAdaptiveGaussian` — log-normal sigma update (strategy parameter co-evolution)

**Requirements:** CRS-02, CRS-03, CRS-04, MUT-05, TRAITS-02  
**Depends on:** Phase 47