### PR TITLE
feat(phase-80): document CmaEngine, PsoEngine, EdaEngine in docs/

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,17 +2,15 @@
 gsd_state_version: 1.0
 milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
-current_phase: 78
-current_phase_name: replace-user-input-panics-with-gaerror-issue-279
 status: executing
-stopped_at: Phase 78 context gathered
-last_updated: "2026-06-20T10:07:22.396Z"
+stopped_at: Phase 80 context gathered
+last_updated: "2026-06-22T17:07:40.740Z"
 progress:
   total_phases: 51
-  completed_phases: 27
+  completed_phases: 30
   total_plans: 102
-  completed_plans: 140
-  percent: 53
+  completed_plans: 145
+  percent: 59
 ---
 
 # Project State
@@ -98,9 +96,9 @@ Progress bar: [██████████████████░░] 45/
 
 ## Session Continuity
 
-Last session: 2026-06-20T10:07:13.850Z
-Stopped at: Phase 78 context gathered
-Resume file: .planning/phases/78-replace-user-input-panics-with-gaerror-issue-279/78-CONTEXT.md
+Last session: 2026-06-22T17:07:40.728Z
+Stopped at: Phase 80 context gathered
+Resume file: .planning/phases/80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is/80-CONTEXT.md
 
 ## Performance Metrics
 

--- a/.planning/phases/79-add-runnable-examples-for-gp-de-scatter-cellular-alps-engine/79-CONTEXT.md
+++ b/.planning/phases/79-add-runnable-examples-for-gp-de-scatter-cellular-alps-engine/79-CONTEXT.md
@@ -1,0 +1,67 @@
+# Phase 79: Add Runnable Examples for GP, DE, Scatter, Cellular, ALPS Engines - Context
+
+**Gathered:** 2026-06-22
+**Status:** Already shipped — context written post-hoc (commit 4f28d45)
+
+<domain>
+## Phase Boundary
+
+Add five standalone runnable examples in `examples/` — one per major non-GA engine (GP, DE, Scatter Search, Cellular GA, ALPS) — and register each in the smoke-test list and README.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Delivery status
+- **D-01:** All five examples were delivered in commit `4f28d45` on `feat/phase-79` branch and merged.
+- **D-02:** All examples registered in `tests/test_examples.rs` (build + run smoke tests).
+- **D-03:** All examples documented in README `## Examples` table at line ~576.
+
+### Claude's Discretion
+All implementation choices (example structure, benchmark problem, parameter values) were made by Claude during execution — no user discussion needed.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+No external specs — phase was pure documentation/examples work. Requirements fully captured in ROADMAP.md phase 79.
+
+### Delivered files
+- `examples/gp_symbolic_regression.rs` — GP symbolic regression with `GpGa<N>` and `MathNode`
+- `examples/de_rastrigin.rs` — Differential Evolution (L-SHADE) on Rastrigin
+- `examples/scatter_search.rs` — Scatter Search on continuous benchmark
+- `examples/cellular_ga.rs` — Cellular GA with Moore neighborhood
+- `examples/alps.rs` — ALPS with age-layered evolution
+- `tests/test_examples.rs` — smoke tests for all five examples
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Established Patterns
+- All examples follow the existing pattern: minimal setup, short generation count, `println!` result at the end.
+- Registered in `tests/test_examples.rs` via `cargo_build_example` + `cargo_run_example` helpers.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+No specific requirements — examples implemented following existing example conventions.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 79-add-runnable-examples-for-gp-de-scatter-cellular-alps-engine*
+*Context gathered: 2026-06-22*

--- a/.planning/phases/80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is/80-CONTEXT.md
+++ b/.planning/phases/80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is/80-CONTEXT.md
@@ -1,0 +1,112 @@
+# Phase 80: Document CmaEngine, PsoEngine, EdaEngine in docs/engines.md - Context
+
+**Gathered:** 2026-06-22
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Add comprehensive documentation for the three currently undocumented engines: CMA-ES (`CmaEngine`), PSO (`PsoEngine`), and EDA (`EdaEngine`/`EdaRealEngine`). All three are fully implemented in `src/engines/` and have runnable examples — but have zero coverage in `docs/engines.md` or `docs/index.md`.
+
+**In scope:**
+- Create `docs/cma.md`, `docs/pso.md`, `docs/eda.md` — dedicated pages following the `nsga3.md`/`moead.md` pattern
+- Add short stub sections (when-to-use + link) to `docs/engines.md` for all three engines
+- Update `docs/index.md` to link the three new pages
+- Update the engine decision matrix in `docs/engines.md` overview table to include CMA/PSO/EDA
+- Zero rustdoc warnings (`cargo doc --no-deps`)
+
+**Out of scope:**
+- Changing any Rust source code
+- Docs for other engines not mentioned
+- Adding new runnable examples (already exist: `cma_es_rastrigin.rs`, `pso_rastrigin.rs`, `eda_trap.rs`)
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Page structure
+- **D-01:** CMA-ES, PSO, and EDA each get a **dedicated docs page** (`docs/cma.md`, `docs/pso.md`, `docs/eda.md`) following the `nsga3.md`/`moead.md` pattern (~130–150 lines each).
+- **D-02:** `docs/engines.md` gets a **short stub section** per engine (when-to-use bullet list + key params + link to dedicated page), NOT a full inline section. Same pattern as NSGA-III inline section in engines.md that links to `nsga3.md`.
+- **D-03:** `docs/index.md` gets entries linking the three new pages under the "Engines" section.
+- **D-04:** The engine overview table at the top of `docs/engines.md` is updated to add rows for `CmaEngine`, `PsoEngine`, and `EdaEngine`/`EdaRealEngine`.
+
+### Snippet style & depth
+- **D-05:** Code snippets in dedicated pages cover **key differentiating config only** — not minimal boilerplate, not a full tutorial:
+  - CMA: show `sigma0` heuristic (1/3 of search range), `RestartStrategy::Ipop` for multimodal, and `lambda = 0` (auto-compute)
+  - PSO: show `PsoInertia::LinearDecay { w_start: 0.9, w_end: 0.4 }` + `PsoTopology::Ring { neighborhood_size: 2 }` as the typical recommended config
+  - EDA: show the Bernoulli model path (`EdaEngine` for binary) vs Gaussian model path (`EdaRealEngine` for continuous) as two contrasting snippets
+
+### Claude's Discretion
+- Parameter table formatting: follow existing `nsga3.md` / `moead.md` Markdown table style
+- "When PSO beats GA" / "When EDA beats crossover-based GAs" content: derive from config docs and engine logic in `src/engines/`
+- Section ordering within each page: Description → When to Use → Configuration (param table) → Key Snippets → See Also (links to example + engines.md)
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Reference patterns (existing dedicated pages to match)
+- `docs/nsga3.md` — structure template: Description, When to Use, Configuration table, code snippet, See Also
+- `docs/moead.md` — second reference for structure and tone
+- `docs/spea2.md` — third reference for structure and tone
+
+### Engine implementations (source of truth for params and behavior)
+- `src/engines/cma/configuration.rs` — `CmaConfiguration` fields with doc comments (sigma0, lambda, restart_strategy, cc/cs/c1/cmu)
+- `src/engines/cma/restart.rs` — `RestartStrategy` enum (Ipop, Bipop) with doc comments
+- `src/engines/pso/configuration.rs` — `PsoConfiguration`, `PsoInertia` enum, `PsoTopology` enum with doc comments
+- `src/engines/eda/configuration.rs` — `EdaConfiguration` and `EdaRealConfiguration` fields
+
+### Existing examples (link targets in See Also sections)
+- `examples/cma_es_rastrigin.rs`
+- `examples/pso_rastrigin.rs`
+- `examples/eda_trap.rs`
+
+### Docs to update
+- `docs/engines.md` — add stub sections + update overview table
+- `docs/index.md` — add links to three new pages
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `docs/nsga3.md`, `docs/moead.md`, `docs/spea2.md`: direct structural templates for new pages (150 lines, Description + When to Use + Configuration table + snippet + See Also)
+- `docs/engines.md` §`Nsga3Ga<U>`: inline stub pattern to replicate for CMA/PSO/EDA (59 lines with link to dedicated page)
+
+### Established Patterns
+- Param tables use `| Field | Type | Default | Description |` header row (see `engines.md` DE/Scatter sections)
+- "When to Use" is a bullet list with: Problem type, Variable type, Key strength, Key weakness
+- Code snippets do NOT import `use genetic_algorithms::*` — they use precise module paths
+- Each dedicated page ends with a `## See Also` section linking back to `engines.md` and the runnable example
+
+### Integration Points
+- `docs/index.md` "Engines" section: add three entries following the existing format
+- `docs/engines.md` overview table: add rows for the three engines (between existing entries — sort by use-case category)
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- CMA sigma0 heuristic to document: "set sigma0 ≈ 1/3 of the expected search range per dimension"
+- PSO recommended defaults to highlight: Clerc's values `c1 = c2 = 1.49445`, `w = 0.729` with Constant inertia; or `w_start=0.9, w_end=0.4` with LinearDecay
+- EDA key distinction: `EdaEngine` uses Bernoulli model (binary genes, UMDA), `EdaRealEngine` uses Gaussian model (continuous genes) — this duality should be clear in the page title and opening paragraph
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is*
+*Context gathered: 2026-06-22*

--- a/.planning/phases/80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is/80-DISCUSSION-LOG.md
+++ b/.planning/phases/80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is/80-DISCUSSION-LOG.md
@@ -1,0 +1,44 @@
+# Phase 80: Document CmaEngine, PsoEngine, EdaEngine in docs/engines.md - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-06-22
+**Phase:** 80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is
+**Areas discussed:** Page structure, Snippet style & depth
+
+---
+
+## Page structure
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Dedicated pages + stubs | cma.md / pso.md / eda.md follow nsga3.md/moead.md pattern; engines.md gets short stub linking to them | ✓ |
+| Inline sections only | All content inline in engines.md like DE/Scatter; no new files; docs/index.md gets anchor links | |
+
+**User's choice:** Dedicated pages + stubs (Recommended)
+**Notes:** Success criteria mention "docs/index.md links the new pages" confirming dedicated-page intent. The nsga3.md/moead.md pattern is the right template.
+
+---
+
+## Snippet style & depth
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Key differentiators only | CMA shows RestartStrategy + sigma0, PSO shows LinearDecay + Ring topology, EDA shows Bernoulli vs Gaussian contrast | ✓ |
+| Minimal boilerplate | Same short snippet style as engines.md inline sections — default values only | |
+
+**User's choice:** Key differentiators only (Recommended)
+**Notes:** CMA/PSO/EDA have meaningful config enums (RestartStrategy, PsoInertia, PsoTopology) that distinguish them from simpler engines. Showing these in snippets is the main value of the documentation.
+
+---
+
+## Claude's Discretion
+
+- Parameter table formatting: follow nsga3.md / moead.md Markdown style
+- "When X beats Y" content: derive from engine source and doc comments
+- Section ordering within dedicated pages: Description → When to Use → Configuration → Snippets → See Also
+
+## Deferred Ideas
+
+None — discussion stayed within phase scope.

--- a/docs/cma.md
+++ b/docs/cma.md
@@ -1,0 +1,105 @@
+# CMA-ES
+
+> Covariance Matrix Adaptation Evolution Strategy — self-adapting continuous optimization with Jacobi eigendecomposition (no LAPACK, WASM-compatible).
+
+## Description
+
+CMA-ES (Hansen & Ostermeier 2001) evolves a multivariate Gaussian search distribution over continuous real-valued space. Each generation it samples `λ` candidate solutions, evaluates their fitness, then updates:
+
+- **Mean** — toward the best candidates.
+- **Covariance matrix** — to learn the shape and orientation of the fitness landscape (rank-one and rank-µ updates).
+- **Step size `σ`** — via a separate cumulation path to control overall scale.
+
+The covariance matrix allows CMA-ES to adapt to correlated/non-separable landscapes that defeat separable optimizers. The implementation uses **Jacobi eigendecomposition** — no LAPACK dependency, fully WASM-compatible.
+
+Module path: `genetic_algorithms::cma`.  
+Public exports: `CmaEngine`, `CmaConfiguration`, `CmaResult`, `RestartStrategy`.
+
+## When to Use
+
+- **Problem type:** Continuous real-valued optimization (sphere, Rosenbrock, Rastrigin, etc.)
+- **Variable type:** `RangeChromosome<f64>` with `RealGene`-bounded genes
+- **Key strength:** Self-adapts the covariance matrix to handle non-separable and correlated fitness landscapes; most internal parameters auto-tune (Hansen's formulas)
+- **Key weakness:** Covariance matrix is O(n²) memory and O(n²) per update — practical upper bound is roughly 40 dimensions; prefer PSO for higher dimensions
+
+## Quick Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sigma0` | `f64` | `0.3` | Initial step size σ₀. Heuristic: typically 1/5 to 1/3 of the expected search range per dimension. |
+| `population_size` | `usize` | `0` (auto) | λ. If 0, auto-computes `4 + floor(3·ln(n))` (Hansen's default) at `run()`. |
+| `max_generations` | `usize` | `1000` | Stop after this many generations. |
+| `problem_solving` | `ProblemSolving` | `Minimization` | Minimize or maximize fitness. |
+| `fitness_target` | `Option<f64>` | `None` | Early-stop when the best fitness reaches this target. |
+| `cc` | `Option<f64>` | `None` | Covariance matrix cumulation rate. `None` = Hansen auto-formula. |
+| `cs` | `Option<f64>` | `None` | Step-size control cumulation rate. `None` = Hansen auto-formula. |
+| `c1` | `Option<f64>` | `None` | Rank-one update rate. `None` = Hansen auto-formula. |
+| `cmu` | `Option<f64>` | `None` | Rank-µ update rate. `None` = Hansen auto-formula. Constraint: `c1 + cmu ≤ 1`. |
+| `restart_strategy` | `Option<RestartStrategy>` | `None` | IPOP or BIPOP restart strategy; `None` = no automatic restarts. |
+| `fitness_cache_size` | `Option<usize>` | `None` | LRU cache capacity for fitness evaluations (avoids re-evaluating duplicate DNA). |
+
+### Restart Strategies
+
+`RestartStrategy` has two variants:
+
+- **`Ipop { population_scale, stagnation_threshold, max_restarts }`** — doubles (or scales by `population_scale`) the population on each stagnation event. Promotes global exploration on multimodal landscapes.
+- **`Bipop { population_scale, small_population_size, stagnation_threshold, max_restarts }`** — alternates between a large restart (IPOP-style, odd restarts) and a small restart (cheap basin exploitation, even restarts).
+
+## Complete Example
+
+```rust,ignore
+use genetic_algorithms::cma::{CmaConfiguration, CmaEngine, RestartStrategy};
+use genetic_algorithms::configuration::ProblemSolving;
+
+const DIMENSIONS: usize = 10;
+
+// default_for_dim sets population_size = 4 + floor(3·ln(n)) automatically
+let config = CmaConfiguration::default_for_dim(DIMENSIONS)
+    // Search domain [-5.12, 5.12] → range 10.24 → sigma0 ≈ 10.24 / 3 ≈ 3.4
+    .with_sigma0(3.4)
+    .with_max_generations(1000)
+    .with_problem_solving(ProblemSolving::Minimization)
+    // IPOP restarts for multimodal landscapes (e.g. Rastrigin)
+    .with_restart_strategy(RestartStrategy::Ipop {
+        population_scale: 2.0,
+        stagnation_threshold: 50,
+        max_restarts: 9,
+    })
+    // Optional: cache repeated DNA evaluations
+    .with_fitness_cache(256);
+
+let mut engine = CmaEngine::new(config, init_population, fitness_fn);
+let result = engine.run().expect("CMA-ES run should succeed");
+
+println!("Generations: {}", result.generations);
+println!("Best fitness: {:.6}", result.best_fitness);
+```
+
+## Configuration Tips
+
+- **sigma0 heuristic:** Set `sigma0` to roughly 1/5 to 1/3 of the expected search range per dimension. For a domain of `[-5.12, 5.12]` (range 10.24), a value of `3.4` is a good starting point. Too-small `sigma0` causes slow convergence; too-large causes noisy search.
+- **population_size = 0 (auto):** `default_for_dim(n)` or leaving `population_size = 0` triggers Hansen's formula `λ = 4 + floor(3·ln(n))`. Increase explicitly for better exploration at the cost of more evaluations per generation.
+- **IPOP restarts:** Use `RestartStrategy::Ipop` when the landscape is multimodal (e.g. Rastrigin). The population doubles on each stagnation event, helping escape local optima. `stagnation_threshold = 50` and `max_restarts = 9` are common starting values.
+- **cc, cs, c1, cmu:** Leave as `None` unless you have strong domain knowledge — Hansen's auto-formulas are near-optimal for most problems.
+
+## When to Choose This vs PSO
+
+| Factor | CMA-ES | PSO |
+|--------|--------|-----|
+| Mechanism | Covariance matrix adaptation (learns landscape geometry) | Swarm velocity + personal/neighborhood best attraction |
+| Hyperparameters | More internal parameters, but most auto-tune (Hansen formulas) | Few parameters (inertia, c1, c2) |
+| Dimensionality | Practical limit ~40 dims (O(n²) covariance overhead) | Scales to higher dimensions (no covariance matrix) |
+| Landscape | Non-separable, correlated, rugged — CMA adapts its distribution shape | Smooth, unimodal — PSO converges fast with Global topology |
+| Multimodal | IPOP/BIPOP restarts add multimodal support | Ring topology helps but premature convergence is a risk |
+
+## References
+
+- Hansen, N., & Ostermeier, A. (2001). Completely derandomized self-adaptation in evolution strategies. _Evolutionary Computation_, 9(2), 159–195.
+- Auger, A., & Hansen, N. (2005). A restart CMA evolution strategy with increasing population size. _Proceedings of the 2005 IEEE Congress on Evolutionary Computation_ (Vol. 2, pp. 1769–1776).
+
+## See Also
+
+- [Engines Overview](engines.md) — Full engine decision matrix and engine selection guide
+- [PSO](pso.md) — Swarm-based alternative for smooth/higher-dimensional landscapes
+- [Example: cma_es_rastrigin](../examples/cma_es_rastrigin.rs) — Runnable 5D Rastrigin minimization
+- [docs.rs/genetic_algorithms::cma](https://docs.rs/genetic_algorithms/latest/genetic_algorithms/cma/index.html) — Module API reference

--- a/docs/eda.md
+++ b/docs/eda.md
@@ -1,0 +1,121 @@
+# EDA (Estimation of Distribution)
+
+> Univariate Marginal Distribution Algorithm (UMDA) — probabilistic model-building optimization for binary (Bernoulli) and continuous (Gaussian) chromosomes.
+
+## Description
+
+EDA in this library ships as two distinct engine types driven by a single `EdaConfiguration`:
+
+- **`EdaEngine<U>`** — Bernoulli model for binary chromosomes (classic UMDA). Use this when your gene type does **not** implement `RealGene`.
+- **`EdaRealEngine<U>`** — Gaussian univariate model for continuous chromosomes. Use this when your gene type implements `RealGene` (e.g., `RangeGenotype<f64>`).
+
+The model is selected by the engine type you instantiate, **not** by a configuration flag. Both engines share the same `EdaConfiguration` struct.
+
+**How UMDA works:** At each generation, the top `selection_ratio` fraction of the population (by fitness) feeds the model estimation step. For the Bernoulli model, the engine estimates `p_i` = fraction of selected individuals with gene `i` equal to 1 at each position, then samples Bernoulli(`p_i`) to produce a completely new population. For the Gaussian model, the engine estimates `(mean_i, std_i)` per position and samples from N(`mean_i`, `std_i`) clamped to gene bounds. There are no crossover or mutation operators — offspring come entirely from the learned model.
+
+The final learned model is returned in `EdaResult::learned_model` as an `EdaModel` enum:
+
+- `EdaModel::Bernoulli(Vec<f64>)` — one probability per position (approaches 0 or 1 at convergence)
+- `EdaModel::Gaussian { means: Vec<f64>, stds: Vec<f64> }` — per-position mean and standard deviation
+
+## When to Use
+
+- **Problem type (Bernoulli):** Binary combinatorial problems with epistasis or deception — trap functions, feature selection, deceptive benchmark landscapes.
+- **Problem type (Gaussian):** Continuous real-valued optimization where variable distributions can be captured by independent univariate Gaussians.
+- **Variable type:** Binary genes for `EdaEngine`; `RealGene`-bounded genes for `EdaRealEngine`.
+- **Key strength:** Model-building avoids crossover disruption of building-block structure. The Bernoulli model learns per-position marginals, which is sufficient for separable or mildly-deceptive problems. EDA naturally handles deceptive binary landscapes that confound crossover-based GAs.
+- **Key weakness:** UMDA is a **univariate** model — it captures only marginal distributions and does **not** model inter-variable dependencies (linkage). For problems with strong epistasis requiring dependency capture, multivariate EDAs (BOA, MIMIC) would be needed. Also, EDA typically requires larger populations than standard GAs to accurately estimate the probabilistic model.
+
+## Quick Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `population_size` | `usize` | `100` | Population size. EDA typically needs larger populations than standard GA to estimate the probability model accurately. |
+| `max_generations` | `usize` | `500` | Stop after this many generations. |
+| `problem_solving` | `ProblemSolving` | `Maximization` | **Note:** EDA defaults to `Maximization`, unlike CMA-ES and PSO which default to `Minimization`. Set this explicitly for minimization problems. |
+| `fitness_target` | `Option<f64>` | `None` | Early-stop when best fitness reaches this target. `None` runs until `max_generations`. |
+| `selection_ratio` | `f64` | `0.5` | Fraction of population used as selected parents for model estimation. Must be in `(0.0, 1.0]`; a minimum of 1 parent is enforced. Default: top 50% (truncation selection). |
+| `fitness_cache_size` | `Option<usize>` | `None` | LRU fitness cache capacity in entries. Avoids redundant evaluations for duplicate DNA. |
+
+## Complete Example
+
+### Binary Chromosomes → Bernoulli UMDA
+
+```rust,ignore
+use genetic_algorithms::chromosomes::Binary as BinaryChromosome;
+use genetic_algorithms::configuration::ProblemSolving;
+use genetic_algorithms::eda::{EdaConfiguration, EdaEngine};
+
+// Configuration — note: Maximization is the default, shown explicitly for clarity
+let config = EdaConfiguration::default()
+    .with_population_size(300)
+    .with_max_generations(500)
+    .with_selection_ratio(0.3)
+    .with_problem_solving(ProblemSolving::Maximization);
+
+// EdaEngine<BinaryChromosome> selects the Bernoulli UMDA model
+let mut engine = EdaEngine::<BinaryChromosome>::new(
+    config,
+    |n| init_population(n),   // fn(usize) -> Vec<BinaryChromosome>
+    trap_fitness,              // fn(&[BinaryGene]) -> f64
+);
+
+let result = engine.run().expect("EDA run failed");
+println!("Best fitness: {:.1}", result.best_fitness);
+println!("Generations: {}", result.generations);
+```
+
+### Continuous Chromosomes → Gaussian Univariate Model
+
+```rust,ignore
+use genetic_algorithms::chromosomes::Range as RangeChromosome;
+use genetic_algorithms::configuration::ProblemSolving;
+use genetic_algorithms::eda::{EdaConfiguration, EdaRealEngine};
+
+// For minimization (e.g., sphere function), override the Maximization default explicitly
+let config = EdaConfiguration::default()
+    .with_population_size(100)
+    .with_max_generations(300)
+    .with_selection_ratio(0.5)
+    .with_problem_solving(ProblemSolving::Minimization);
+
+// EdaRealEngine<RangeChromosome<f64>> selects the Gaussian univariate model
+let mut engine = EdaRealEngine::<RangeChromosome<f64>>::new(
+    config,
+    |n| init_population(n),   // fn(usize) -> Vec<RangeChromosome<f64>>
+    sphere_fitness,            // fn(&[RangeGenotype<f64>]) -> f64
+);
+
+let result = engine.run().expect("EDA run failed");
+println!("Best fitness: {:.6}", result.best_fitness);
+```
+
+## Configuration Tips
+
+- **Population size:** Use larger populations than you would for a standard GA. Model estimation quality depends on sample size — 100 to 500 is common for binary problems. The example (`eda_trap`) uses 300.
+- **Selection ratio:** Values between 0.3 and 0.5 (truncation) are typical. Lower ratios (e.g., 0.3) apply tighter selection pressure; higher ratios (e.g., 0.5) preserve more diversity.
+- **Problem solving direction:** `EdaConfiguration` defaults to `Maximization`. If you are solving a minimization problem, call `.with_problem_solving(ProblemSolving::Minimization)` explicitly — this is a common source of confusion since CMA-ES and PSO default to `Minimization`.
+- **Fitness cache:** Enable via `.with_fitness_cache_size(n)` when your fitness function is expensive and duplicate chromosomes are common (e.g., binary problems late in convergence).
+- **Early stopping:** Use `.with_fitness_target(t)` to halt when the optimum is known (e.g., `30.0` for a trap function of length 30).
+
+## When to Choose This vs Crossover-Based GAs
+
+| Factor | EDA (UMDA) | Crossover-Based GA |
+|--------|------------|-------------------|
+| Mechanism | Model-building + sampling | Crossover + mutation |
+| Building-block preservation | Preserved: marginal model learns per-position frequencies | Disrupted: crossover splits blocks |
+| Variable dependencies | Univariate marginals only (no linkage capture) | Implicit via linkage in crossover |
+| Typical use | Deceptive binary problems; separable continuous problems | General-purpose; well-studied landscapes |
+| Population requirement | Larger (model estimation quality) | Smaller (direct recombination) |
+| Operators needed | None (no crossover or mutation) | Crossover + mutation required |
+
+## References
+
+- Mühlenbein, H., & Paaß, G. (1996). From recombination of genes to the estimation of distributions I. Binary parameters. _Parallel Problem Solving from Nature — PPSN IV_, LNCS 1141, 178–187.
+- Larrañaga, P., & Lozano, J. A. (Eds.). (2002). _Estimation of Distribution Algorithms: A New Tool for Evolutionary Computation_. Kluwer Academic Publishers.
+
+## See Also
+
+- [Engines Overview](engines.md) — Full engine decision matrix and EDA entry
+- [Example: eda_trap](../examples/eda_trap.rs) — Runnable UMDA on a deceptive trap function
+- [docs.rs/genetic_algorithms::eda](https://docs.rs/genetic_algorithms/latest/genetic_algorithms/eda/index.html) — Module API reference

--- a/docs/engines.md
+++ b/docs/engines.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The library provides twelve engines for different problem structures and evolutionary strategies:
+The library provides fifteen engines for different problem structures and evolutionary strategies:
 
 | Engine | Module | Output type | Use case |
 |--------|--------|-------------|----------|
@@ -15,6 +15,9 @@ The library provides twelve engines for different problem structures and evoluti
 | `CellularEngine<U>` | `cellular` | Best + final grid | Spatial locality — neighbourhood-only competition |
 | `AlpsEngine<U>` | `alps` | Best + layer results | Prevent premature convergence via age layers |
 | `GpGa<N>` | `gp` | `GpResult<N>` (best tree + population) | Genetic Programming — symbolic regression, program synthesis |
+| `CmaEngine<U>` | `cma` | Best f64 vector | Continuous optimisation — self-adaptive covariance matrix |
+| `PsoEngine<U>` | `pso` | Best vector | Swarm-based continuous optimisation — few hyperparameters |
+| `EdaEngine<U>` / `EdaRealEngine<U>` | `eda` | Best individual | Probabilistic model-building — binary (Bernoulli) or continuous (Gaussian) |
 | `Nsga2Ga<U>` | `nsga2` | Pareto front | 2-objective optimisation |
 | `Nsga3Ga<U>` | `nsga3` | Pareto front | 3+ objective (many-objective) optimisation |
 | `MoeaDGa<U>` | `moead` | Pareto front | Decomposition-based multi-objective |
@@ -127,6 +130,145 @@ println!("Best: {} (fitness={:.4})", result.best, result.best_fitness);
 ```
 
 **Added in:** v3.0.0
+
+---
+
+## `CmaEngine<U>` — CMA-ES
+
+Covariance Matrix Adaptation Evolution Strategy. Evolves a multivariate Gaussian search distribution over continuous real-valued space, self-adapting the covariance matrix to handle non-separable and correlated fitness landscapes. Uses Jacobi eigendecomposition — no LAPACK, fully WASM-compatible.
+
+**Entry point:** `src/engines/cma/`
+
+### When to Use
+
+- **Problem type:** Continuous real-valued optimization (sphere, Rosenbrock, Rastrigin, etc.)
+- **Variable type:** `RangeChromosome<f64>` with `RealGene`-bounded genes
+- **Key strength:** Self-adapts to non-separable and correlated landscapes; most internal parameters auto-tune (Hansen's formulas)
+- **Key weakness:** O(n²) memory and update cost — practical upper bound ~40 dimensions; prefer PSO for higher dimensions
+
+### Configuration
+
+```rust,ignore
+use genetic_algorithms::cma::{CmaConfiguration, CmaEngine, RestartStrategy};
+use genetic_algorithms::configuration::ProblemSolving;
+
+let config = CmaConfiguration::default_for_dim(10)
+    .with_sigma0(3.4)
+    .with_restart_strategy(RestartStrategy::Ipop {
+        population_scale: 2,
+        stagnation_threshold: 50,
+        max_restarts: 3,
+    })
+    .with_fitness_cache(200)
+    .with_problem_solving(ProblemSolving::Minimization);
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `sigma0` | `f64` | `0.3` | Initial step size; heuristic: 1/5 to 1/3 of expected search range per dimension |
+| `population_size` | `usize` | `0` (auto) | λ. Auto-computes `4 + floor(3·ln(n))` at `run()` if 0 |
+| `max_generations` | `usize` | `1000` | Generation limit |
+| `restart_strategy` | `Option<RestartStrategy>` | `None` | IPOP or BIPOP restarts; `None` = no restarts |
+| `fitness_cache_size` | `Option<usize>` | `None` | LRU cache capacity for fitness evaluations |
+
+### See Also
+
+- [Full CMA-ES guide](cma.md)
+- [Example: cma_es_rastrigin](../examples/cma_es_rastrigin.rs)
+
+---
+
+## `PsoEngine<U>` — Particle Swarm Optimization
+
+Swarm-based continuous optimizer. Each particle tracks its personal best and is attracted toward the neighborhood best, balancing exploration (inertia) and exploitation (cognitive + social terms). Scales to higher dimensions than CMA-ES since there is no covariance matrix.
+
+**Entry point:** `src/engines/pso/`
+
+### When to Use
+
+- **Problem type:** Continuous real-valued optimization where gradients are unavailable
+- **Variable type:** `RangeChromosome<f64>` with `RealGene`-bounded genes
+- **Key strength:** Few hyperparameters; fast convergence on smooth/unimodal landscapes; no covariance matrix overhead
+- **Key weakness:** Prone to premature convergence on multimodal problems with Global topology; no correlation modeling
+
+### Configuration
+
+```rust,ignore
+use genetic_algorithms::pso::{PsoConfiguration, PsoEngine, PsoInertia, PsoTopology};
+use genetic_algorithms::configuration::ProblemSolving;
+
+let config = PsoConfiguration::default()
+    .with_inertia(PsoInertia::LinearDecay { w_start: 0.9, w_end: 0.4 })
+    .with_topology(PsoTopology::Ring { neighborhood_size: 2 })
+    .with_c1(1.49445)
+    .with_c2(1.49445)
+    .with_problem_solving(ProblemSolving::Minimization);
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `population_size` | `usize` | `30` | Number of particles in the swarm |
+| `inertia` | `PsoInertia` | `LinearDecay { 0.9, 0.4 }` | `Constant(f64)` or `LinearDecay { w_start, w_end }` |
+| `c1` | `f64` | `2.0` | Cognitive coefficient — personal-best attraction strength |
+| `c2` | `f64` | `2.0` | Social coefficient — neighborhood-best attraction strength |
+| `topology` | `PsoTopology` | `Global` | `Global` (gbest) or `Ring { neighborhood_size }` (lbest) |
+
+### See Also
+
+- [Full PSO guide](pso.md)
+- [Example: pso_rastrigin](../examples/pso_rastrigin.rs)
+
+---
+
+## `EdaEngine<U>` / `EdaRealEngine<U>` — Estimation of Distribution
+
+Probabilistic model-building optimization (UMDA). No crossover or mutation operators — offspring are sampled entirely from a learned probability model. `EdaEngine<U>` uses a Bernoulli model for binary chromosomes; `EdaRealEngine<U>` uses a Gaussian univariate model for real-valued chromosomes. Both share `EdaConfiguration`.
+
+**Entry point:** `src/engines/eda/`
+
+### When to Use
+
+- **Problem type (Bernoulli):** Binary deceptive/epistasis problems (trap functions, feature selection)
+- **Problem type (Gaussian):** Continuous separable problems where univariate Gaussian marginals suffice
+- **Key strength:** Model-building preserves building blocks, naturally handling deceptive binary landscapes
+- **Key weakness:** Univariate model — captures only marginal distributions; no inter-variable linkage (epistasis)
+
+### Configuration
+
+```rust,ignore
+use genetic_algorithms::eda::{EdaConfiguration, EdaEngine, EdaRealEngine};
+use genetic_algorithms::configuration::ProblemSolving;
+
+// Binary → Bernoulli model
+let bin_config = EdaConfiguration::default()
+    .with_population_size(300)
+    .with_selection_ratio(0.3)
+    .with_problem_solving(ProblemSolving::Maximization); // EDA defaults to Maximization
+
+// Continuous → Gaussian model
+let real_config = EdaConfiguration::default()
+    .with_population_size(200)
+    .with_problem_solving(ProblemSolving::Minimization);
+```
+
+### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `population_size` | `usize` | `100` | Population size; EDA needs larger populations than standard GA |
+| `max_generations` | `usize` | `500` | Generation limit |
+| `problem_solving` | `ProblemSolving` | `Maximization` | **Note:** Defaults to Maximization — set explicitly for minimization |
+| `selection_ratio` | `f64` | `0.5` | Fraction of top individuals used for model estimation (truncation selection) |
+| `fitness_cache_size` | `Option<usize>` | `None` | LRU cache capacity for fitness evaluations |
+
+### See Also
+
+- [Full EDA guide](eda.md)
+- [Example: eda_trap](../examples/eda_trap.rs)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ All guides are written following the Single Source of Truth (SSOT) principle, wh
 ### Getting Started
 - [Getting Started](getting-started.md) — Installation, quickstart, and basic concepts for new users
 
-### Engines (12 total)
+### Engines (15 total)
 
 Each engine has a dedicated guide covering algorithm description, when-to-use guidance, parameter tables, and complete examples:
 
@@ -24,6 +24,9 @@ Each engine has a dedicated guide covering algorithm description, when-to-use gu
 - [ALPS](engines.md#alpsengineu--age-layered-population-structure) — Age-layered diversity with 3 age schemes (Linear, Fibonacci, Polynomial)
 - [Island Model](engines.md#islandgau--island-model) — Parallel sub-populations with configurable migration topologies
 - [Genetic Programming](gp.md) — Tree chromosome evolution with `GpGa<N>`, subtree/point/hoist mutation, bloat control, and built-in primitive sets
+- [CMA-ES](cma.md) — Covariance Matrix Adaptation Evolution Strategy for continuous optimization
+- [PSO](pso.md) — Particle Swarm Optimization with configurable inertia and topology
+- [EDA](eda.md) — Univariate Marginal Distribution Algorithm (Bernoulli and Gaussian models)
 - [NSGA-II](engines.md#nsga2gau--nsga-ii) — Pareto-ranking multi-objective optimization (2 objectives)
 - [NSGA-III](nsga3.md) — Reference-point based many-objective optimization (3+ objectives)
 - [MOEA/D](moead.md) — Decomposition-based multi-objective optimization

--- a/docs/pso.md
+++ b/docs/pso.md
@@ -1,0 +1,113 @@
+# PSO
+
+> Particle Swarm Optimization — swarm-based continuous optimization with configurable inertia strategies and neighborhood topologies.
+
+## Description
+
+PSO (Kennedy & Eberhart 1995) evolves a swarm of particles across a continuous real-valued search space. Each particle maintains:
+
+- **Position** — the current candidate solution.
+- **Velocity** — direction and magnitude of movement.
+- **Personal best** — the best position this particle has ever visited.
+
+On each generation, velocity is updated from three components:
+
+1. **Inertia** — retains a fraction of the current velocity (controls exploration vs exploitation balance).
+2. **Cognitive term** — pulls the particle toward its personal best (weighted by `c1`).
+3. **Social term** — pulls the particle toward the best position found by its neighborhood (weighted by `c2`).
+
+PSO has few hyperparameters, no covariance matrix overhead, and converges fast on smooth landscapes.
+
+Module path: `genetic_algorithms::pso`.  
+Public exports: `PsoEngine`, `PsoConfiguration`, `PsoInertia`, `PsoTopology`.
+
+## When to Use
+
+- **Problem type:** Continuous real-valued optimization where gradients are unavailable
+- **Variable type:** `RangeChromosome<f64>` with `RealGene`-bounded genes
+- **Key strength:** Few hyperparameters, fast convergence on smooth/unimodal landscapes; scales to higher dimensions than CMA-ES (no covariance matrix)
+- **Key weakness:** Prone to premature convergence on multimodal problems with Global topology; no correlation modeling
+
+## Quick Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `population_size` | `usize` | `30` | Number of particles in the swarm. |
+| `max_generations` | `usize` | `1000` | Stop after this many generations. |
+| `problem_solving` | `ProblemSolving` | `Minimization` | Minimize or maximize fitness. |
+| `fitness_target` | `Option<f64>` | `None` | Early-stop when the best fitness reaches this target. |
+| `inertia` | `PsoInertia` | `LinearDecay { w_start: 0.9, w_end: 0.4 }` | Velocity retention strategy (see below). |
+| `c1` | `f64` | `2.0` | Cognitive coefficient — personal-best attraction strength. |
+| `c2` | `f64` | `2.0` | Social coefficient — neighborhood-best attraction strength. |
+| `topology` | `PsoTopology` | `Global` | Neighborhood topology (see below). |
+| `fitness_cache_size` | `Option<usize>` | `None` | LRU cache capacity for fitness evaluations. |
+
+### Inertia Strategies
+
+`PsoInertia` has two variants:
+
+- **`Constant(f64)`** — fixed inertia weight every generation. Common value: `0.729` (Clerc's constriction coefficient) when paired with `c1 = c2 = 1.49445`.
+- **`LinearDecay { w_start: f64, w_end: f64 }`** — linearly decreases from `w_start` to `w_end` over the run. Recommended defaults (Shi & Eberhart 1998): `w_start = 0.9, w_end = 0.4`. High initial inertia promotes broad exploration; low final inertia promotes fine-grained exploitation.
+
+### Topologies
+
+`PsoTopology` has two variants:
+
+- **`Global`** — gbest topology: every particle is attracted toward the single global best position ever found. Fast convergence but prone to premature convergence on multimodal landscapes.
+- **`Ring { neighborhood_size: usize }`** — lbest topology: each particle is attracted toward the best position within its `neighborhood_size` nearest neighbors by index (ring-wrapped). For `neighborhood_size = 2`, the neighborhood of particle `i` is `{ i-1, i, i+1 }`. Slower convergence but better exploration on multimodal problems.
+
+## Complete Example
+
+```rust,ignore
+use genetic_algorithms::pso::{PsoConfiguration, PsoEngine, PsoInertia, PsoTopology};
+use genetic_algorithms::configuration::ProblemSolving;
+
+// Typical recommended config: LinearDecay + Ring for multimodal landscapes.
+// Clerc's constriction: Constant(0.729) with c1=c2=1.49445 is a stable alternative.
+let config = PsoConfiguration::default()
+    .with_population_size(50)
+    .with_max_generations(1000)
+    .with_problem_solving(ProblemSolving::Minimization)
+    .with_inertia(PsoInertia::LinearDecay { w_start: 0.9, w_end: 0.4 })
+    .with_topology(PsoTopology::Ring { neighborhood_size: 2 })
+    .with_c1(1.49445)
+    .with_c2(1.49445)
+    // Optional: cache repeated DNA evaluations
+    .with_fitness_cache_size(256);
+
+let mut engine = PsoEngine::new(config, init_population, fitness_fn);
+let result = engine.run().expect("PSO run should succeed");
+
+println!("Generations: {}", result.generations);
+println!("Best fitness: {:.6}", result.best_fitness);
+```
+
+## Configuration Tips
+
+- **Global topology** converges fastest on unimodal or smooth landscapes — use when the search space has a single basin.
+- **Ring topology** trades convergence speed for multimodal exploration. `neighborhood_size = 2` (3-particle neighborhood) is a conservative starting point; larger values approximate Global.
+- **Clerc's constriction:** Use `PsoInertia::Constant(0.729)` with `c1 = c2 = 1.49445`. This is a stable alternative to `LinearDecay` and avoids manual tuning of the inertia schedule.
+- **LinearDecay defaults** (`w_start = 0.9, w_end = 0.4`) from Shi & Eberhart (1998) are a good starting point for most problems and are the library default.
+- **population_size:** PSO literature standard is 30 particles (dimension-independent). Increase for higher-dimensional or multimodal problems.
+
+## When to Choose This vs CMA-ES
+
+| Factor | PSO | CMA-ES |
+|--------|-----|--------|
+| Mechanism | Swarm velocity + personal/neighborhood best | Covariance matrix adaptation (learns landscape geometry) |
+| Hyperparameters | Few (inertia, c1, c2) | More internal parameters, but most auto-tune (Hansen formulas) |
+| Dimensionality | Scales to higher dimensions — no covariance overhead | Practical limit ~40 dims (O(n²) covariance update) |
+| Landscape correlation | No correlation modeling | Adapts to non-separable, correlated landscapes |
+| Convergence on smooth | Fast with Global topology | Competitive but heavier per-generation update |
+
+## References
+
+- Kennedy, J., & Eberhart, R. (1995). Particle swarm optimization. _Proceedings of the 1995 IEEE International Conference on Neural Networks_ (Vol. 4, pp. 1942–1948).
+- Shi, Y., & Eberhart, R. (1998). A modified particle swarm optimizer. _Proceedings of the 1998 IEEE International Conference on Evolutionary Computation_ (pp. 69–73).
+
+## See Also
+
+- [Engines Overview](engines.md) — Full engine decision matrix and engine selection guide
+- [CMA-ES](cma.md) — Covariance-adapting alternative for correlated/rugged landscapes
+- [Example: pso_rastrigin](../examples/pso_rastrigin.rs) — Runnable 10D Rastrigin minimization
+- [docs.rs/genetic_algorithms::pso](https://docs.rs/genetic_algorithms/latest/genetic_algorithms/pso/index.html) — Module API reference


### PR DESCRIPTION
## Summary

- Creates `docs/cma.md`, `docs/pso.md`, `docs/eda.md` — dedicated engine guide pages following the `nsga3.md`/`moead.md` structure (description, when-to-use, parameter table, key snippets, see-also)
- Updates `docs/engines.md` overview table with CMA/PSO/EDA rows and adds NSGA-III-style stub sections for all three; count updated from "twelve" to "fifteen engines"
- Updates `docs/index.md` with three navigation entries under `### Engines (15 total)`
- `cargo doc --no-deps` exits 0 with 0 warnings; closes #282

## Key decisions baked in

- PSO documents only `Constant` and `LinearDecay` inertia, `Global` and `Ring` topology — non-existent variants (`RandomRange`, `VonNeumann`) intentionally omitted
- EDA page leads with the dual-engine split: `EdaEngine` (Bernoulli/binary) vs `EdaRealEngine` (Gaussian/continuous)
- EDA `Maximization` default called out explicitly (unlike CMA/PSO which default to Minimization)

## Test plan

- [x] `cargo doc --no-deps` — 0 warnings (verified in 80-03 rustdoc gate)
- [x] All ROADMAP.md Phase 80 success criteria met (6/6, VERIFICATION.md passed)
- [x] PSO variants cross-checked against `src/engines/pso/configuration.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)