### PR TITLE
Merge feat/phase-80: Phase 81-82 (prelude, convergence tests)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1355,7 +1355,12 @@ Plans:
   5. `docs/index.md` links the new pages
   6. Zero rustdoc warnings (`cargo doc --no-deps`)
 
-**Plans**: TBD
+**Plans**: 3/3 plans complete
+
+- [x] 80-01-PLAN.md — Create docs/cma.md + docs/pso.md dedicated pages
+- [x] 80-02-PLAN.md — Create docs/eda.md dedicated page (Bernoulli + Gaussian)
+- [x] 80-03-PLAN.md — engines.md overview table + stubs, index.md links, rustdoc gate
+
 **UI hint**: no
 
 ### Phase 81: Add a Prelude Module for Ergonomic Imports (Issue #283)
@@ -1373,7 +1378,18 @@ Plans:
   6. Documented in README / getting-started guide
   7. `cargo doc --no-deps` clean; `cargo test` clean
 
-**Plans**: TBD
+**Plans**: 2 plans
+
+Plans:
+
+**Wave 1**
+
+- [ ] 81-01-PLAN.md — Create prelude module + lib.rs declaration + tests
+
+**Wave 2** *(blocked on Wave 1)*
+
+- [ ] 81-02-PLAN.md — Update rastrigin example + documentation
+
 **UI hint**: no
 
 ### Phase 82: Per-Engine Convergence Integration Tests (Issue #284)
@@ -1471,6 +1487,6 @@ Plans:
 | 77. Extend Fitness Cache to More Engines (#260) | v3.0.0 | 1/1 | Complete   | 2026-06-19 |
 | 78. Replace User-Input Panics with GaError (#279) | v3.0.0 | 1/4 | In Progress|  |
 | 79. Add Runnable Examples for GP, DE, Scatter, Cellular, ALPS (#281) | v3.0.0 | TBD | Pending | — |
-| 80. Document CmaEngine, PsoEngine, EdaEngine (#282) | v3.0.0 | TBD | Pending | — |
+| 80. Document CmaEngine, PsoEngine, EdaEngine (#282) | v3.0.0 | 3/3 | Complete   | 2026-06-22 |
 | 81. Add Prelude Module (#283) | v3.0.0 | TBD | Pending | — |
 | 82. Per-Engine Convergence Integration Tests (#284) | v3.0.0 | TBD | Pending | — |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1399,17 +1399,22 @@ Plans:
 **Requirements**: None (testing — closes GitHub issue #284)
 **Success Criteria** (what must be TRUE):
 
-  1. `DeEngine` convergence test — Rastrigin or Sphere → best fitness within tolerance of global minimum
-  2. `ScatterEngine` convergence test — continuous benchmark → converges
-  3. `CellularEngine` convergence test — Rastrigin/Sphere → converges
-  4. `AlpsEngine` convergence test — Rastrigin/Sphere → converges
-  5. `CmaEngine` convergence test — Rastrigin → converges; includes IPOP/BIPOP restart path
-  6. `PsoEngine` convergence test — Rastrigin/Sphere → converges
-  7. All tests use fixed RNG seed (`with_rng_seed`) for determinism and generous-but-bounded budget
-  8. Tests placed under `tests/engines/<engine>/` next to existing unit tests
+  1. `DeEngine` convergence test — Sphere 5D → best_fitness < 1.0 within 300 generations
+  2. `ScatterEngine` convergence test — Sphere 5D → best_fitness < 1.0 within 300 iterations
+  3. `CellularEngine` convergence test — Sphere 5D → best_fitness < 1.0 within 300 generations
+  4. `AlpsEngine` convergence test — Sphere 5D → best_fitness < 1.0 within 300 generations
+  5. `CmaEngine` convergence test — Sphere 5D → best_fitness < 1.0 within 300 generations; separate IPOP restart convergence test
+  6. `PsoEngine` convergence test — Sphere 5D → best_fitness < 1.0 within 300 generations
+  7. All tests use fixed RNG seed 42 for determinism
+  8. Tests placed under `tests/engines/<engine>/` in existing test files
   9. `cargo test` and `cargo test --features serde` pass
 
-**Plans**: TBD
+**Plans:** 1 plan
+
+Plans:
+
+- [ ] 82-01-PLAN.md — Add 7 convergence tests across 6 engine test files (DE, Scatter, Cellular, ALPS, CMA+IPOP, PSO)
+
 **UI hint**: no
 
 ## Progress
@@ -1489,4 +1494,4 @@ Plans:
 | 79. Add Runnable Examples for GP, DE, Scatter, Cellular, ALPS (#281) | v3.0.0 | TBD | Pending | — |
 | 80. Document CmaEngine, PsoEngine, EdaEngine (#282) | v3.0.0 | 3/3 | Complete   | 2026-06-22 |
 | 81. Add Prelude Module (#283) | v3.0.0 | 2/2 | Complete    | 2026-06-22 |
-| 82. Per-Engine Convergence Integration Tests (#284) | v3.0.0 | TBD | Pending | — |
+| 82. Per-Engine Convergence Integration Tests (#284) | v3.0.0 | 1/1 | Planned | — |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1384,11 +1384,11 @@ Plans:
 
 **Wave 1**
 
-- [ ] 81-01-PLAN.md — Create prelude module + lib.rs declaration + tests
+- [x] 81-01-PLAN.md — Create prelude module + lib.rs declaration + tests
 
 **Wave 2** *(blocked on Wave 1)*
 
-- [ ] 81-02-PLAN.md — Update rastrigin example + documentation
+- [x] 81-02-PLAN.md — Update rastrigin example + documentation
 
 **UI hint**: no
 
@@ -1488,5 +1488,5 @@ Plans:
 | 78. Replace User-Input Panics with GaError (#279) | v3.0.0 | 1/4 | In Progress|  |
 | 79. Add Runnable Examples for GP, DE, Scatter, Cellular, ALPS (#281) | v3.0.0 | TBD | Pending | — |
 | 80. Document CmaEngine, PsoEngine, EdaEngine (#282) | v3.0.0 | 3/3 | Complete   | 2026-06-22 |
-| 81. Add Prelude Module (#283) | v3.0.0 | TBD | Pending | — |
+| 81. Add Prelude Module (#283) | v3.0.0 | 2/2 | Complete    | 2026-06-22 |
 | 82. Per-Engine Convergence Integration Tests (#284) | v3.0.0 | TBD | Pending | — |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
-status: ready_to_plan
-stopped_at: Phase 81 complete (2/2) — ready to discuss Phase 82
-last_updated: 2026-06-22T20:49:01.800Z
+status: planning
+stopped_at: Phase 82 context gathered
+last_updated: "2026-06-22T20:56:03.441Z"
 progress:
-  total_phases: 51
-  completed_phases: 31
+  total_phases: 52
+  completed_phases: 32
   total_plans: 107
-  completed_plans: 166
-  percent: 61
+  completed_plans: 150
+  percent: 62
 ---
 
 # Project State
@@ -96,9 +96,9 @@ Progress bar: [██████████████████░░] 45/
 
 ## Session Continuity
 
-Last session: 2026-06-22T19:19:43.560Z
-Stopped at: Phase 81 context gathered
-Resume file: .planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-CONTEXT.md
+Last session: 2026-06-22T20:56:03.434Z
+Stopped at: Phase 82 context gathered
+Resume file: .planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-CONTEXT.md
 
 ## Performance Metrics
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,15 +2,15 @@
 gsd_state_version: 1.0
 milestone: v3.0.0
 milestone_name: — Advanced Representations, Alternative Strategies & Architecture Simplification
-status: executing
-stopped_at: Phase 80 context gathered
-last_updated: "2026-06-22T17:07:40.740Z"
+status: ready_to_plan
+stopped_at: Phase 81 complete (2/2) — ready to discuss Phase 82
+last_updated: 2026-06-22T20:49:01.800Z
 progress:
   total_phases: 51
-  completed_phases: 30
-  total_plans: 102
-  completed_plans: 145
-  percent: 59
+  completed_phases: 31
+  total_plans: 107
+  completed_plans: 166
+  percent: 61
 ---
 
 # Project State
@@ -21,14 +21,14 @@ See: .planning/PROJECT.md (updated 2026-05-18)
 
 **Core value:** Users can solve complex optimization problems with composable, performant genetic algorithms — without fighting the library
 **Core value:** Users can solve complex optimization problems with composable, performant genetic algorithms — without fighting the library
-**Current focus:** Phase 78 — replace-user-input-panics-with-gaerror-issue-279
+**Current focus:** Phase 82 — per engine convergence integration tests (issue #284)
 
 ## Current Position
 
-Phase: 78 (replace-user-input-panics-with-gaerror-issue-279) — EXECUTING
-Plan: 2 of 4
+Phase: 82
+Plan: Not started
 Plans: 138/138 complete (new phases have no plans yet)
-Status: Ready to execute
+Status: Ready to plan
 
 Progress bar: [██████████████████░░] 45/50 phases complete
 
@@ -96,9 +96,9 @@ Progress bar: [██████████████████░░] 45/
 
 ## Session Continuity
 
-Last session: 2026-06-22T17:07:40.728Z
-Stopped at: Phase 80 context gathered
-Resume file: .planning/phases/80-document-cmaengine-psoengine-edaengine-in-docs-engines-md-is/80-CONTEXT.md
+Last session: 2026-06-22T19:19:43.560Z
+Stopped at: Phase 81 context gathered
+Resume file: .planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-CONTEXT.md
 
 ## Performance Metrics
 
@@ -112,3 +112,6 @@ Resume file: .planning/phases/80-document-cmaengine-psoengine-edaengine-in-docs-
 | Phase 76 P01 | 1min | 1 task | 2 files |
 | Phase 76 P02 | 8min | 2 tasks | 3 files |
 | Phase 78 P01 | 5min | 3 tasks | 6 files |
+| Phase 80 P01 | 5min | 2 tasks | 2 files |
+| Phase Phase 80 PP02 | 2min | 1 task tasks | 1 file files |
+| Phase 80 P03 | 5min | 2 tasks | 2 files |

--- a/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-01-PLAN.md
+++ b/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-01-PLAN.md
@@ -1,0 +1,248 @@
+---
+phase: 81-add-a-prelude-module-for-ergonomic-imports-issue-283
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - src/prelude.rs
+  - src/lib.rs
+  - tests/test_prelude.rs
+  - tests/test_prelude_minimal_ga.rs
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - "Users can write use genetic_algorithms::prelude::*; and access all engine entry points, core traits, operator enums, config types, and error types"
+    - "A minimal GA can be built and run using only prelude imports plus concrete chromosome/genotype types"
+    - "No glob-import name collisions exist when the prelude is used"
+  artifacts:
+    - path: "src/prelude.rs"
+      provides: "Prelude module with pub use re-exports for all high-frequency items"
+      min_lines: 60
+    - path: "src/lib.rs"
+      provides: "pub mod prelude declaration"
+      contains: "pub mod prelude"
+    - path: "tests/test_prelude.rs"
+      provides: "Compile-check tests verifying prelude re-exports are accessible"
+      min_lines: 40
+    - path: "tests/test_prelude_minimal_ga.rs"
+      provides: "Integration test building a minimal GA with only prelude imports"
+      min_lines: 30
+  key_links:
+    - from: "src/prelude.rs"
+      to: "src/lib.rs"
+      via: "pub mod prelude declaration"
+      pattern: "pub mod prelude"
+    - from: "tests/test_prelude.rs"
+      to: "src/prelude.rs"
+      via: "use genetic_algorithms::prelude::*"
+      pattern: "use genetic_algorithms::prelude::\\*"
+---
+
+<objective>
+Create the prelude module and verify it compiles with no name collisions.
+
+Purpose: Enable users to write `use genetic_algorithms::prelude::*;` instead of 8-11 separate import lines (closes GitHub issue #283). This is purely additive — no existing public API changes.
+
+Output: `src/prelude.rs` (new), `src/lib.rs` (modified — add module declaration), `tests/test_prelude.rs` (new), `tests/test_prelude_minimal_ga.rs` (new).
+</objective>
+
+<execution_context>
+@/Users/luis/.config/opencode/gsd-core/workflows/execute-plan.md
+@/Users/luis/.config/opencode/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-CONTEXT.md
+@.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-RESEARCH.md
+@.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-PATTERNS.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create src/prelude.rs and add module declaration to src/lib.rs</name>
+  <files>src/prelude.rs, src/lib.rs</files>
+  <read_first>
+    - src/lib.rs (lines 320-437 — existing pub mod declarations and pub use re-exports)
+    - src/traits.rs (lines 55-74 — trait re-exports: ChromosomeT, GeneT, LinearChromosome, ConfigurationT, CrossoverConfig, ElitismConfig, ExtensionConfig, LocalSearchConfig, MutationConfig, NichingConfig, SelectionConfig, StoppingConfig, SurvivorConfig)
+    - src/operations.rs (lines 57, 144, 336, 451 — operator enums: Selection, Crossover, Mutation, Survivor)
+    - src/configuration.rs (line 63 — ProblemSolving enum)
+    - src/error.rs (line 46 — GaError enum)
+    - src/observe/observer/mod.rs (lines 98, 172 — GaObserver trait, NoopObserver struct)
+    - .planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-PATTERNS.md (grouped re-export pattern and feature-gated pattern)
+  </read_first>
+  <action>
+Create `src/prelude.rs` as a new file containing grouped `pub use crate::...` re-exports. The file must include a rustdoc module doc-comment explaining the prelude's purpose and a table of included items.
+
+**Re-export groups (per D-01, D-02, D-03, D-04, D-05):**
+
+1. Engine entry points (19 engines):
+   - `pub use crate::ga::Ga;`
+   - `pub use crate::de::DeEngine;`
+   - `pub use crate::scatter::ScatterEngine;`
+   - `pub use crate::cellular::CellularEngine;`
+   - `pub use crate::alps::AlpsEngine;`
+   - `pub use crate::island::IslandGa;`
+   - `pub use crate::gp::GpGa;`
+   - `pub use crate::eda::{EdaEngine, EdaRealEngine};`
+   - `pub use crate::nsga2::Nsga2Ga;`
+   - `pub use crate::nsga3::Nsga3Ga;`
+   - `pub use crate::moead::MoeaDGa;`
+   - `pub use crate::spea2::Spea2Ga;`
+   - `pub use crate::sms_emoa::SmsEmoaGa;`
+   - `pub use crate::ibea::IbeaGa;`
+   - `pub use crate::cma::CmaEngine;`
+   - `pub use crate::pso::PsoEngine;`
+   - `pub use crate::hill_climb::HillClimbEngine;`
+   - `pub use crate::permutate::PermutateEngine;`
+
+2. Engine-specific configuration structs (10 structs):
+   - `pub use crate::cma::CmaConfiguration;`
+   - `pub use crate::pso::PsoConfiguration;`
+   - `pub use crate::eda::EdaConfiguration;`
+   - `pub use crate::alps::AlpsConfiguration;`
+   - `pub use crate::hill_climb::HillClimbConfiguration;`
+   - `pub use crate::permutate::PermutateConfiguration;`
+   - `pub use crate::de::DeConfiguration;`
+   - `pub use crate::scatter::ScatterConfiguration;`
+   - `pub use crate::cellular::CellularConfiguration;`
+   - `pub use crate::gp::GpConfiguration;`
+
+3. Core traits (13 traits):
+   - `pub use crate::traits::{ChromosomeT, ConfigurationT, GeneT, LinearChromosome, CrossoverConfig, ElitismConfig, ExtensionConfig, LocalSearchConfig, MutationConfig, NichingConfig, SelectionConfig, StoppingConfig, SurvivorConfig};`
+
+4. Operator enums (4 enums):
+   - `pub use crate::operations::{Crossover, Mutation, Selection, Survivor};`
+
+5. Configuration types:
+   - `pub use crate::configuration::ProblemSolving;`
+   - `pub use crate::chromosomes::ChromosomeLength;`
+
+6. Error:
+   - `pub use crate::error::GaError;`
+
+7. Observer (minimal — per D-04):
+   - `pub use crate::observer::{GaObserver, NoopObserver};`
+
+8. Feature-gated observers (per D-05):
+   - `#[cfg(feature = "logging")] pub use crate::observer::LogObserver;`
+   - `#[cfg(feature = "observer-metrics")] pub use crate::observer::MetricsObserver;`
+   - `#[cfg(feature = "observer-tracing")] pub use crate::observer::TracingObserver;`
+
+Then edit `src/lib.rs`: add `pub mod prelude;` alphabetically among the existing `pub mod` declarations. Place it after `pub mod population;` (line 342) and before `pub mod rng;` (line 343).
+  </action>
+  <verify>
+    <automated>cargo check</automated>
+  </verify>
+  <acceptance_criteria>
+    - src/prelude.rs exists and contains `pub use crate::ga::Ga;`
+    - src/prelude.rs contains `pub use crate::traits::{ChromosomeT, ConfigurationT, GeneT, LinearChromosome`
+    - src/prelude.rs contains `pub use crate::operations::{Crossover, Mutation, Selection, Survivor};`
+    - src/prelude.rs contains `pub use crate::configuration::ProblemSolving;`
+    - src/prelude.rs contains `pub use crate::error::GaError;`
+    - src/prelude.rs contains `pub use crate::observer::{GaObserver, NoopObserver};`
+    - src/prelude.rs contains `#[cfg(feature = "logging")]` before LogObserver re-export
+    - src/prelude.rs contains `#[cfg(feature = "observer-metrics")]` before MetricsObserver re-export
+    - src/prelude.rs contains `#[cfg(feature = "observer-tracing")]` before TracingObserver re-export
+    - src/lib.rs contains `pub mod prelude;` after `pub mod population;` and before `pub mod rng;`
+    - `cargo check` exits 0 with no errors
+  </acceptance_criteria>
+  <done>src/prelude.rs exists with all required re-exports grouped by category; src/lib.rs has `pub mod prelude;` declaration; `cargo check` passes with zero errors.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create prelude compile-check and integration tests</name>
+  <files>tests/test_prelude.rs, tests/test_prelude_minimal_ga.rs</files>
+  <read_first>
+    - src/prelude.rs (created in Task 1 — verify re-export contents)
+    - tests/observe/observer/test_observer_reexports.rs (analog pattern for compile-check test)
+    - tests/test_no_logger_installed.rs (analog pattern for integration test with GA builder)
+    - src/genotypes/binary.rs (Binary genotype for test GA)
+    - src/chromosomes/binary.rs (BinaryChromosome for test GA)
+    - src/initializers/binary_initializer.rs (binary_random_initialization function)
+  </read_first>
+  <action>
+Create two test files:
+
+**`tests/test_prelude.rs`** — Compile-check test verifying all prelude re-exports are accessible via glob import. Structure:
+- Module doc-comment explaining this is a compile-time verification
+- `use genetic_algorithms::prelude::*;` at the top
+- Test `test_prelude_engines_accessible`: construct a type reference for `Ga` (e.g., `let _: fn() -> Ga<genetic_algorithms::chromosomes::Binary> = || unimplemented!();`)
+- Test `test_prelude_traits_accessible`: use trait bounds in a function signature (`fn assert_traits<T: ChromosomeT + LinearChromosome>() {}`) and reference it
+- Test `test_prelude_operator_enums_accessible`: construct enum variants `Selection::Tournament`, `Crossover::Uniform`, `Mutation::BitFlip`, `Survivor::Fitness`
+- Test `test_prelude_config_types_accessible`: construct `ProblemSolving::Minimization`, `ChromosomeLength::Fixed(5)`
+- Test `test_prelude_error_accessible`: construct `GaError::ConfigurationError("test".into())`
+- Test `test_prelude_observer_accessible`: construct `NoopObserver`
+
+**`tests/test_prelude_minimal_ga.rs`** — Integration test that builds and runs a minimal GA using only prelude imports plus concrete types. Structure:
+- `use genetic_algorithms::prelude::*;`
+- `use genetic_algorithms::chromosomes::Binary as BinaryChromosome;`
+- `use genetic_algorithms::genotypes::Binary;`
+- `use genetic_algorithms::initializers::binary_random_initialization;`
+- Helper function `count_ones(genes: &[Binary]) -> f64` counting true values
+- Test `test_prelude_minimal_ga`: build a `Ga<BinaryChromosome>` with population_size=4, chromosome_length=Fixed(4), binary_random_initialization, count_ones fitness, Selection::Random, Crossover::Uniform, Mutation::BitFlip, Survivor::Fitness, ProblemSolving::Maximization, max_generations=1; call `ga.run()` and assert success
+  </action>
+  <verify>
+    <automated>cargo test test_prelude -- --nocapture</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/test_prelude.rs exists with `use genetic_algorithms::prelude::*;` at the top
+    - tests/test_prelude.rs contains test function `test_prelude_engines_accessible`
+    - tests/test_prelude.rs contains test function `test_prelude_traits_accessible`
+    - tests/test_prelude.rs contains test function `test_prelude_operator_enums_accessible`
+    - tests/test_prelude.rs contains test function `test_prelude_config_types_accessible`
+    - tests/test_prelude.rs contains test function `test_prelude_error_accessible`
+    - tests/test_prelude.rs contains test function `test_prelude_observer_accessible`
+    - tests/test_prelude_minimal_ga.rs exists with `use genetic_algorithms::prelude::*;` at the top
+    - tests/test_prelude_minimal_ga.rs contains test function `test_prelude_minimal_ga`
+    - `cargo test test_prelude` exits 0 with all prelude tests passing
+  </acceptance_criteria>
+  <done>Both test files exist; `cargo test test_prelude` passes with 0 failures; compile-check tests verify no name collisions; integration test verifies a minimal GA builds and runs with prelude imports.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+N/A — this phase adds no runtime behavior, no input handling, no auth/crypto. It is a pure re-export module.
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-81-01 | N/A | src/prelude.rs | accept | Pure re-exports with zero runtime behavior; no trust boundaries crossed |
+</threat_model>
+
+<verification>
+1. `cargo check` — prelude module compiles with no errors
+2. `cargo test test_prelude` — all compile-check and integration tests pass
+3. `cargo clippy --all-targets` — no warnings
+4. `cargo test --doc` — doc-tests pass
+</verification>
+
+<success_criteria>
+- `src/prelude.rs` exists with all required re-exports (engines, configs, traits, operator enums, error, observer)
+- `src/lib.rs` has `pub mod prelude;` declaration
+- `cargo test test_prelude` passes (compile-check + integration)
+- No name collisions when using `use genetic_algorithms::prelude::*;`
+</success_criteria>
+
+<artifacts_this_phase>
+## Artifacts This Phase Produces
+
+| Symbol | Kind | File | Notes |
+|--------|------|------|-------|
+| `prelude` | module | `src/prelude.rs` | New pub mod re-exporting high-frequency items |
+| `pub mod prelude` | declaration | `src/lib.rs` | Module declaration added to lib.rs |
+</artifacts_this_phase>
+
+<output>
+Create `.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-01-SUMMARY.md` when done
+</output>

--- a/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-01-SUMMARY.md
+++ b/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-01-SUMMARY.md
@@ -1,0 +1,107 @@
+---
+phase: 81-add-a-prelude-module-for-ergonomic-imports-issue-283
+plan: 01
+subsystem: api
+tags: [prelude, ergonomic-imports, re-exports, glob-import]
+
+# Dependency graph
+requires:
+  - phase: 80
+    provides: "All engine entry points, core traits, operator enums, and config types"
+provides:
+  - "Prelude module with grouped pub use re-exports for all high-frequency items"
+  - "Compile-check tests verifying no name collisions"
+  - "Integration test building a minimal GA with only prelude imports"
+affects: [examples, documentation, user-facing API]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [prelude-module, grouped-reexports, feature-gated-observers]
+
+key-files:
+  created:
+    - src/prelude.rs
+    - tests/test_prelude.rs
+    - tests/test_prelude_minimal_ga.rs
+  modified:
+    - src/lib.rs
+
+key-decisions:
+  - "Grouped re-exports by category (engines, configs, traits, operators, error, observer) for readability"
+  - "Feature-gated observers mirror src/lib.rs feature gates exactly"
+
+patterns-established:
+  - "Prelude pattern: grouped pub use re-exports with rustdoc table of included items"
+  - "Feature-gated re-exports: #[cfg(feature = \"...\")] before optional observer types"
+
+requirements-completed: []
+
+# Metrics
+duration: 2min
+completed: 2026-06-22
+---
+
+# Phase 81 Plan 01: Add a Prelude Module for Ergonomic Imports Summary
+
+**Prelude module enabling `use genetic_algorithms::prelude::*;` to replace 8-11 separate import lines with a single glob import**
+
+## Performance
+
+- **Duration:** 2 min
+- **Started:** 2026-06-22T20:41:42Z
+- **Completed:** 2026-06-22T20:44:29Z
+- **Tasks:** 2
+- **Files modified:** 4
+
+## Accomplishments
+- Created `src/prelude.rs` with 19 engine entry points, 10 engine configs, 13 core traits, 4 operator enums, config types, error, and feature-gated observers
+- Added `pub mod prelude;` declaration to `src/lib.rs`
+- 7 compile-check and integration tests verify no name collisions and end-to-end GA functionality using only prelude imports
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create src/prelude.rs and add module declaration to src/lib.rs** - `5d50de0` (feat)
+2. **Task 2: Create prelude compile-check and integration tests** - `2208563` (test)
+3. **Style: Apply cargo fmt to prelude files** - `a94ea8f` (style)
+
+## Files Created/Modified
+- `src/prelude.rs` - New prelude module with grouped pub use re-exports for all high-frequency items
+- `src/lib.rs` - Added `pub mod prelude;` declaration after `pub mod population;`
+- `tests/test_prelude.rs` - 6 compile-check tests verifying re-export categories (engines, traits, operator enums, config types, error, observer)
+- `tests/test_prelude_minimal_ga.rs` - Integration test building and running a minimal GA using only prelude imports
+
+## Decisions Made
+- Grouped re-exports by category (engines, configs, traits, operators, error, observer) for readability
+- Feature-gated observers (`LogObserver`, `MetricsObserver`, `TracingObserver`) mirror `src/lib.rs` feature gates exactly
+- Concrete chromosome/genotype types and initializer functions intentionally excluded from prelude — they are problem-specific
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Prelude module complete, users can write `use genetic_algorithms::prelude::*;`
+- Ready for next plan (81-02) to update examples and documentation to use prelude imports
+
+## Self-Check: PASSED
+
+- src/prelude.rs exists
+- tests/test_prelude.rs exists
+- tests/test_prelude_minimal_ga.rs exists
+- 81-01-SUMMARY.md exists
+- feat(81-01) commit present
+- test(81-01) commit present
+- docs(81-01) commit present
+
+---
+*Phase: 81-add-a-prelude-module-for-ergonomic-imports-issue-283*
+*Completed: 2026-06-22*

--- a/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-02-PLAN.md
+++ b/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-02-PLAN.md
@@ -1,0 +1,209 @@
+---
+phase: 81-add-a-prelude-module-for-ergonomic-imports-issue-283
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - 81-01
+files_modified:
+  - examples/rastrigin.rs
+  - README.md
+  - docs/getting-started.md
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - "examples/rastrigin.rs uses use genetic_algorithms::prelude::*; as its primary import"
+    - "README.md documents the prelude in an Ergonomic Imports subsection"
+    - "docs/getting-started.md documents the prelude in a Using the Prelude section"
+  artifacts:
+    - path: "examples/rastrigin.rs"
+      provides: "Updated example using prelude imports instead of 11 separate import lines"
+      contains: "use genetic_algorithms::prelude::*"
+    - path: "README.md"
+      provides: "Ergonomic Imports documentation section"
+      contains: "use genetic_algorithms::prelude::*"
+    - path: "docs/getting-started.md"
+      provides: "Using the Prelude documentation section"
+      contains: "use genetic_algorithms::prelude::*"
+  key_links:
+    - from: "examples/rastrigin.rs"
+      to: "src/prelude.rs"
+      via: "use genetic_algorithms::prelude::*"
+      pattern: "use genetic_algorithms::prelude::\\*"
+    - from: "README.md"
+      to: "src/prelude.rs"
+      via: "documentation referencing prelude module"
+      pattern: "prelude"
+---
+
+<objective>
+Update the rastrigin example and documentation to showcase the prelude.
+
+Purpose: Demonstrate the ergonomic benefit of the prelude by updating the canonical example (D-06) and documenting the prelude in README and getting-started guide (D-07).
+
+Output: `examples/rastrigin.rs` (modified), `README.md` (modified), `docs/getting-started.md` (modified).
+</objective>
+
+<execution_context>
+@/Users/luis/.config/opencode/gsd-core/workflows/execute-plan.md
+@/Users/luis/.config/opencode/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-CONTEXT.md
+@.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-RESEARCH.md
+@.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-PATTERNS.md
+@.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-01-SUMMARY.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Update examples/rastrigin.rs to use prelude imports (D-06)</name>
+  <files>examples/rastrigin.rs</files>
+  <read_first>
+    - examples/rastrigin.rs (full file — current import section lines 23-37)
+    - src/prelude.rs (verify which items are in the prelude)
+    - .planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-PATTERNS.md (rastrigin before/after pattern)
+  </read_first>
+  <action>
+Replace the import section of `examples/rastrigin.rs` (lines 23-37) with the prelude-based imports per D-06.
+
+**Current imports (11 lines, lines 23-37):**
+```
+use genetic_algorithms::chromosomes::Range as RangeChromosome;
+use genetic_algorithms::configuration::ProblemSolving;
+use genetic_algorithms::ga::{Ga, TerminationCause};
+use genetic_algorithms::genotypes::Range as RangeGenotype;
+use genetic_algorithms::initializers::range_random_initialization;
+use genetic_algorithms::operations::{Crossover, GaussianParams, Mutation, Selection, Survivor};
+use genetic_algorithms::population::Population;
+use genetic_algorithms::stats::GenerationStats;
+use genetic_algorithms::traits::{
+    ChromosomeT, ConfigurationT, CrossoverConfig, MutationConfig, SelectionConfig, StoppingConfig,
+};
+#[cfg(feature = "observer-metrics")]
+use genetic_algorithms::MetricsObserver;
+use genetic_algorithms::{rng, ChromosomeLength, CompositeObserver, LogObserver};
+use std::sync::Arc;
+```
+
+**Target imports (reduced — prelude covers the common items):**
+```
+use genetic_algorithms::prelude::*;
+use genetic_algorithms::chromosomes::Range as RangeChromosome;
+use genetic_algorithms::genotypes::Range as RangeGenotype;
+use genetic_algorithms::initializers::range_random_initialization;
+// Non-prelude items used only in this example:
+use genetic_algorithms::ga::TerminationCause;
+use genetic_algorithms::operations::GaussianParams;
+use genetic_algorithms::population::Population;
+use genetic_algorithms::stats::GenerationStats;
+use genetic_algorithms::{rng, CompositeObserver};
+#[cfg(feature = "observer-metrics")]
+use genetic_algorithms::MetricsObserver;
+use std::sync::Arc;
+```
+
+Items now covered by the prelude glob (removed from explicit imports): `ProblemSolving`, `Ga`, `Crossover`, `Mutation`, `Selection`, `Survivor`, `ChromosomeT`, `ConfigurationT`, `CrossoverConfig`, `MutationConfig`, `SelectionConfig`, `StoppingConfig`, `ChromosomeLength`, `LogObserver`.
+
+Items remaining explicit (not in prelude, example-specific): `TerminationCause`, `GaussianParams`, `Population`, `GenerationStats`, `rng`, `CompositeObserver`, `MetricsObserver`, `RangeChromosome`, `RangeGenotype`, `range_random_initialization`.
+
+Do NOT change any code after line 37 — only the import section is modified.
+  </action>
+  <verify>
+    <automated>cargo build --example rastrigin</automated>
+  </verify>
+  <acceptance_criteria>
+    - examples/rastrigin.rs line 23 is `use genetic_algorithms::prelude::*;`
+    - examples/rastrigin.rs contains `use genetic_algorithms::chromosomes::Range as RangeChromosome;`
+    - examples/rastrigin.rs contains `use genetic_algorithms::genotypes::Range as RangeGenotype;`
+    - examples/rastrigin.rs contains `use genetic_algorithms::initializers::range_random_initialization;`
+    - examples/rastrigin.rs does NOT contain `use genetic_algorithms::configuration::ProblemSolving;` (now in prelude)
+    - examples/rastrigin.rs does NOT contain `use genetic_algorithms::operations::{Crossover,` (now in prelude)
+    - examples/rastrigin.rs does NOT contain `use genetic_algorithms::traits::{` (now in prelude)
+    - `cargo build --example rastrigin` exits 0
+  </acceptance_criteria>
+  <done>examples/rastrigin.rs uses `use genetic_algorithms::prelude::*;` as primary import; 11 import lines reduced to ~12 lines (prelude glob + concrete types + example-specific items); `cargo build --example rastrigin` passes.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add prelude documentation to README.md and docs/getting-started.md (D-07)</name>
+  <files>README.md, docs/getting-started.md</files>
+  <read_first>
+    - README.md (find the Quick Start section — typically around lines 110-153)
+    - docs/getting-started.md (find the First Run section — typically around lines 53-80)
+    - .planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-PATTERNS.md (README and getting-started documentation patterns)
+  </read_first>
+  <action>
+Add prelude documentation to both files per D-07:
+
+**README.md** — Add an "Ergonomic Imports" subsection after the Quick Start code block. The subsection should:
+- Show `use genetic_algorithms::prelude::*;` as the primary import
+- Show explicit imports for concrete chromosome/genotype types and initializer functions
+- Explain that the prelude includes all engine entry points, configuration traits, operator enums, core traits, and error types
+- Note that concrete chromosome/genotype types and initializer functions are imported separately since they are problem-specific
+
+**docs/getting-started.md** — Add a "Using the Prelude" section after the First Run code example. The section should:
+- Show the prelude-based import pattern
+- Explain what the prelude re-exports
+- Note that concrete types remain explicit imports
+  </action>
+  <verify>
+    <automated>cargo doc --no-deps</automated>
+  </verify>
+  <acceptance_criteria>
+    - README.md contains a section header with "Ergonomic Imports" or "Prelude"
+    - README.md contains `use genetic_algorithms::prelude::*;`
+    - docs/getting-started.md contains a section header with "Prelude"
+    - docs/getting-started.md contains `use genetic_algorithms::prelude::*;`
+    - `cargo doc --no-deps` exits 0
+  </acceptance_criteria>
+  <done>README.md and docs/getting-started.md both document the prelude with usage examples; `cargo doc --no-deps` passes cleanly.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+N/A — this phase adds no runtime behavior, no input handling, no auth/crypto. Documentation and example changes only.
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-81-02 | N/A | docs/examples | accept | Documentation and example changes with zero security impact |
+</threat_model>
+
+<verification>
+1. `cargo build --example rastrigin` — example compiles with prelude imports
+2. `cargo doc --no-deps` — documentation builds cleanly
+3. `cargo test` — all existing tests still pass
+4. `cargo clippy --all-targets` — no warnings
+</verification>
+
+<success_criteria>
+- `examples/rastrigin.rs` uses `use genetic_algorithms::prelude::*;` as primary import
+- README.md has an "Ergonomic Imports" section documenting the prelude
+- docs/getting-started.md has a "Using the Prelude" section documenting the prelude
+- `cargo build --example rastrigin` passes
+- `cargo doc --no-deps` passes
+</success_criteria>
+
+<artifacts_this_phase>
+## Artifacts This Phase Produces
+
+| Symbol | Kind | File | Notes |
+|--------|------|------|-------|
+| (none — documentation and example updates only) | — | — | No new symbols; existing example and docs updated |
+</artifacts_this_phase>
+
+<output>
+Create `.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-02-SUMMARY.md` when done
+</output>

--- a/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-02-SUMMARY.md
+++ b/.planning/phases/81-add-a-prelude-module-for-ergonomic-imports-issue-283/81-02-SUMMARY.md
@@ -1,0 +1,117 @@
+---
+phase: 81-add-a-prelude-module-for-ergonomic-imports-issue-283
+plan: 02
+subsystem: api
+tags: [prelude, ergonomic-imports, documentation, examples]
+
+# Dependency graph
+requires:
+  - phase: 81
+    plan: 01
+    provides: "Prelude module with grouped pub use re-exports for all high-frequency items"
+provides:
+  - "Updated rastrigin example using prelude imports"
+  - "README.md Ergonomic Imports documentation section"
+  - "docs/getting-started.md Using the Prelude section"
+affects: [examples, documentation, user-facing API]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [prelude-usage-pattern, documentation-prelude-section]
+
+key-files:
+  created: []
+  modified:
+    - examples/rastrigin.rs
+    - README.md
+    - docs/getting-started.md
+
+key-decisions:
+  - "Prelude glob replaces 8-11 import lines; concrete types remain explicit"
+
+patterns-established:
+  - "Prelude usage: use genetic_algorithms::prelude::*; + explicit concrete types"
+  - "Documentation pattern: show prelude import block after Quick Start / First Run examples"
+
+requirements-completed: []
+
+# Metrics
+duration: 1min
+completed: 2026-06-22
+---
+
+# Phase 81 Plan 02: Update Example and Documentation to Showcase Prelude Summary
+
+**Rastrigin example using prelude imports, README and getting-started guide documenting ergonomic import pattern**
+
+## Performance
+
+- **Duration:** 1 min
+- **Started:** 2026-06-22T20:46:14Z
+- **Completed:** 2026-06-22T20:48:01Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+- Updated `examples/rastrigin.rs` to use `use genetic_algorithms::prelude::*;` as primary import, reducing 11 explicit import lines to the prelude glob plus 10 example-specific items
+- Added "Ergonomic Imports" subsection to README.md Quick Start section
+- Added "Using the Prelude" section to docs/getting-started.md
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Update examples/rastrigin.rs to use prelude imports** - `45f4676` (feat)
+2. **Task 2: Add prelude documentation to README.md and docs/getting-started.md** - `1c6ddb1` (docs)
+
+## Files Created/Modified
+- `examples/rastrigin.rs` - Replaced 11 separate import lines with prelude glob + explicit concrete types
+- `README.md` - Added "Ergonomic Imports" subsection after Quick Start code block
+- `docs/getting-started.md` - Added "Using the Prelude" section after First Run example
+
+## Decisions Made
+- Prelude glob replaces all items in the prelude; concrete chromosome/genotype types and initializer functions remain explicit since they are problem-specific
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Phase 81 complete: prelude module created (Plan 01) and example/documentation updated (Plan 02)
+- Ready for next phase or milestone completion
+
+## Self-Check: PASSED
+
+- examples/rastrigin.rs contains `use genetic_algorithms::prelude::*;`
+- README.md contains "Ergonomic Imports" section
+- docs/getting-started.md contains "Using the Prelude" section
+- `cargo build --example rastrigin` passes
+- `cargo doc --no-deps` passes
+- `cargo test` passes (291 tests)
+- `cargo clippy --all-targets` clean
+- feat(81-02) commit present: `45f4676`
+- docs(81-02) commit present: `1c6ddb1`
+
+## Self-Check: PASSED (appended)
+
+- examples/rastrigin.rs contains `use genetic_algorithms::prelude::*;`
+- README.md contains "Ergonomic Imports" section
+- docs/getting-started.md contains "Using the Prelude" section
+- `cargo build --example rastrigin` passes
+- `cargo doc --no-deps` passes
+- `cargo test` passes (291 tests)
+- `cargo clippy --all-targets` clean
+- feat(81-02) commit present: `45f4676`
+- docs(81-02) commit present: `1c6ddb1`
+- docs(81-02) SUMMARY commit present: `57868d7`
+
+---
+*Phase: 81-add-a-prelude-module-for-ergonomic-imports-issue-283*
+*Completed: 2026-06-22*

--- a/.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-CONTEXT.md
+++ b/.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-CONTEXT.md
@@ -1,0 +1,140 @@
+# Phase 82: Per-Engine Convergence Integration Tests (Issue #284) - Context
+
+**Gathered:** 2026-06-22
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Add end-to-end convergence tests for every single-objective engine (DeEngine, ScatterEngine, CellularEngine, AlpsEngine, CmaEngine, PsoEngine) asserting each reaches a known optimum within tolerance. Prevents silent regressions in search dynamics.
+
+**In scope:**
+- Convergence test for DeEngine (Sphere)
+- Convergence test for ScatterEngine (Sphere)
+- Convergence test for CellularEngine (Sphere)
+- Convergence test for AlpsEngine (Sphere)
+- Convergence test for CmaEngine (Sphere, no restart)
+- Convergence test for CmaEngine with IPOP restart path
+- Convergence test for PsoEngine (Sphere)
+- All tests use fixed RNG seed for determinism
+- Tests placed under `tests/engines/<engine>/`
+- `cargo test` and `cargo test --features serde` pass
+
+**Out of scope:**
+- Changing any engine implementation
+- Adding new engines or operators
+- Multi-objective engine convergence tests
+- Performance benchmarks (separate concern)
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Benchmark Function Choice
+- **D-01:** All engines use **Sphere** function (f(x) = Σ xᵢ², global minimum = 0 at origin)
+- **D-02:** DeEngine: Sphere — matches existing `test_de.rs` helper
+- **D-03:** ScatterEngine: Sphere — matches existing `test_scatter.rs` helper
+- **D-04:** CellularEngine: Sphere — consistent with other engines
+- **D-05:** AlpsEngine: Sphere — consistent with other engines
+- **D-06:** CmaEngine: Sphere — matches existing `test_cma.rs` helper
+- **D-07:** PsoEngine: Sphere — matches existing `test_pso.rs` helper
+
+### Convergence Thresholds
+- **D-08:** Uniform threshold across all engines: **best_fitness < 1.0** on 5-dim Sphere
+- **D-09:** Threshold is loose enough for stochastic engines, tight enough to prove convergence
+- **D-10:** Matches existing CMA/PSO test patterns (`fitness_target(1.0)`)
+
+### Budget Parameters
+- **D-11:** Sphere dimension: **5** (matches existing tests)
+- **D-12:** Population size: **30** (matches existing DE/Scatter tests)
+- **D-13:** Max generations/iterations: **300** (matches existing DE test)
+- **D-14:** All tests use fixed RNG seed via `rng::set_seed(Some(seed))` for determinism
+
+### CMA Restart Testing
+- **D-15:** CMA restart tested in a **separate test** from basic convergence
+- **D-16:** Only **IPOP** restart strategy tested (simpler, well-tested in existing CMA tests)
+- **D-17:** Restart test asserts convergence AND that restart occurred (via observer spy or restart counter)
+
+### Test File Organization
+- **D-18:** Each engine's convergence test added to its existing test file (`tests/engines/<engine>/test_<engine>.rs`)
+- **D-19:** Reuse existing helper functions (`sphere`, `random_pop`) already defined in each test file
+- **D-20:** New convergence tests follow existing test naming convention: `test_<engine>_convergence`
+
+### Agent's Discretion
+- Exact test function names and internal structure
+- Whether to extract shared `sphere` helper to a common module (currently duplicated)
+- Specific assertion messages and error context
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Phase Scope
+- `.planning/ROADMAP.md` §Phase 82 — success criteria and test requirements
+
+### Existing Test Files (must not break)
+- `tests/engines/de/test_de.rs` — existing DE tests with `sphere` helper and convergence pattern
+- `tests/engines/scatter/test_scatter.rs` — existing Scatter tests with `sphere` helper
+- `tests/engines/cellular/test_cellular.rs` — existing Cellular tests
+- `tests/engines/alps/test_alps.rs` — existing ALPS tests
+- `tests/engines/cma/test_cma.rs` — existing CMA tests with restart tests (CMA-12 through CMA-16)
+- `tests/engines/pso/test_pso.rs` — existing PSO tests with convergence pattern
+
+### Engine Configurations
+- `src/engines/de/configuration.rs` — `DeConfiguration` fields (population_size, max_generations, mutation_strategy, crossover_mode)
+- `src/engines/scatter/configuration.rs` — `ScatterConfiguration` fields (population_size, reference_set_size, max_iterations)
+- `src/engines/cellular/configuration.rs` — `CellularConfiguration` fields
+- `src/engines/alps/configuration.rs` — `AlpsConfiguration` fields
+- `src/engines/cma/configuration.rs` — `CmaConfiguration` fields (sigma0, lambda, restart_strategy)
+- `src/engines/pso/configuration.rs` — `PsoConfiguration` fields (population_size, max_generations, inertia, topology)
+
+### RNG Setup
+- `src/rng.rs` — `set_seed()` and `make_rng()` functions for deterministic tests
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `sphere` helper function: already defined in `test_de.rs`, `test_scatter.rs`, `test_cma.rs`, `test_pso.rs` — can be reused directly
+- `random_pop` helper function: already defined in all engine test files — builds random `RangeChromosome<f64>` population
+- `SpyObserver` pattern: exists in `test_cma.rs` and `test_pso.rs` — can be used for CMA restart assertion
+
+### Established Patterns
+- Fixed seed setup: `rng::set_seed(Some(seed))` before population initialization
+- Engine configuration: `DeConfiguration::default().with_*()` builder pattern
+- Convergence assertion: `assert!(result.best_fitness < THRESHOLD, "message")`
+- Determinism: all tests use seed 42 or similar fixed values
+
+### Integration Points
+- `tests/engines/<engine>/test_<engine>.rs` — add new convergence test functions to existing files
+- Each test file already has the necessary imports and helpers
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Reuse the existing `sphere` and `random_pop` helpers already defined in each test file — no need to duplicate
+- For CMA restart test, use the existing `SpyObserver` pattern from `test_cma.rs` to assert restart occurred
+- All convergence tests should have clear assertion messages: `"Engine should converge to sphere minimum < 1.0; got {}"`
+- Consider adding a comment at the top of each convergence test explaining it's a regression test for search dynamics
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope.
+
+</deferred>
+
+---
+
+*Phase: 82-per-engine-convergence-integration-tests-issue-284*
+*Context gathered: 2026-06-22*

--- a/.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-DISCUSSION-LOG.md
+++ b/.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-DISCUSSION-LOG.md
@@ -1,0 +1,165 @@
+# Phase 82: Per-Engine Convergence Integration Tests (Issue #284) - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-06-22
+**Phase:** 82-per-engine-convergence-integration-tests-issue-284
+**Areas discussed:** Benchmark function choice, Convergence thresholds, Budget parameters, CMA restart testing
+
+---
+
+## Benchmark function choice
+
+### DeEngine
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Sphere (Recommended) | Matches existing DE tests. Simpler, faster, still validates convergence. | ✓ |
+| Rastrigin | Harder multimodal test. Would prove DE escapes local optima. | |
+| Both | Two separate convergence tests — Sphere for basic, Rastrigin for multimodal. | |
+
+**User's choice:** Sphere (Recommended)
+**Notes:** Consistent with existing `test_de.rs` helper functions.
+
+### CellularEngine
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Sphere (Recommended) | Consistent with other engines. Cellular GA's spatial structure already tested in unit tests. | ✓ |
+| Rastrigin | Would test if cellular structure helps escape local optima. Harder convergence target. | |
+| Both | Two tests — Sphere for basic, Rastrigin for multimodal. | |
+
+**User's choice:** Sphere (Recommended)
+**Notes:** Consistent with other engines.
+
+### AlpsEngine
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Sphere (Recommended) | Consistent with existing tests. ALPS age-layering is the differentiator, not multimodal escape. | ✓ |
+| Rastrigin | ALPS age layers might help escape local optima on Rastrigin. More rigorous test. | |
+| Both | Two tests — Sphere for basic, Rastrigin for multimodal. | |
+
+**User's choice:** Sphere (Recommended)
+**Notes:** Consistent with other engines.
+
+### PsoEngine
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Sphere (Recommended) | Matches existing PSO tests. PSO convergence on Sphere is well-studied. | ✓ |
+| Rastrigin | PSO can struggle with multimodal — would be a harder convergence test. | |
+| Both | Two tests — Sphere for basic, Rastrigin for multimodal. | |
+
+**User's choice:** Sphere (Recommended)
+**Notes:** Consistent with other engines.
+
+### ScatterEngine
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Sphere (Recommended) | Same as other engines. Scatter already uses Sphere in existing test_scatter.rs. Consistent. | ✓ |
+| Rastrigin | Harder test for Scatter's diversification + reference set combination. | |
+| Ackley | Another common continuous benchmark. More complex landscape than Sphere. | |
+
+**User's choice:** Sphere (Recommended)
+**Notes:** All engines use Sphere for consistency.
+
+---
+
+## Convergence thresholds
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Uniform threshold (Recommended) | All engines use same tolerance (e.g., best_fitness < 1.0 on 5-dim sphere). Simple, consistent. | ✓ |
+| Engine-specific | Each engine gets its own threshold based on its dynamics. More accurate but harder to maintain. | |
+| Tiered | Easy ( < 10.0), Medium ( < 1.0), Hard ( < 0.1) — each engine targets a tier. | |
+
+**User's choice:** Uniform threshold (Recommended)
+**Notes:** Simplicity and consistency preferred.
+
+### Threshold value
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| < 1.0 (Recommended) | Matches existing CMA/PSO tests. Tight enough to prove convergence, loose enough for stochastic engines. | ✓ |
+| < 0.1 | Very tight. May require more generations for some engines. Proves strong convergence. | |
+| < 5.0 | Loose. Matches existing DE test. Quick to converge but less rigorous. | |
+| < 0.01 | Extremely tight. May fail for some engines without large budgets. | |
+
+**User's choice:** < 1.0 (Recommended)
+**Notes:** Matches existing CMA/PSO test patterns.
+
+---
+
+## Budget parameters
+
+### Dimension
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 5 dimensions (Recommended) | Matches existing tests. Fast, still meaningful. 5 variables = 5 search dimensions. | ✓ |
+| 10 dimensions | Harder. More representative of real problems. Takes longer. | |
+| 3 dimensions | Easiest. Very fast convergence. May not stress engines enough. | |
+
+**User's choice:** 5 dimensions (Recommended)
+**Notes:** Matches existing tests.
+
+### Population size
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 30 (Recommended) | Matches existing DE/Scatter tests. Good balance of speed and convergence ability. | ✓ |
+| 50 | Larger population. More diversity, better convergence, but slower tests. | |
+| 20 | Smaller population. Faster tests, but may struggle to converge. | |
+
+**User's choice:** 30 (Recommended)
+**Notes:** Matches existing tests.
+
+### Max generations/iterations
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| 300 (Recommended) | Matches existing DE test. Generous budget for convergence. Tests run in < 1s. | ✓ |
+| 500 | Extra generous. Ensures convergence even for slower engines. Slightly slower tests. | |
+| 100 | Tight budget. Tests fail fast if engine doesn't converge. May be too strict. | |
+
+**User's choice:** 300 (Recommended)
+**Notes:** Matches existing DE test.
+
+---
+
+## CMA restart testing
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Separate restart test (Recommended) | One test for basic convergence (no restart), one test specifically for restart path. Clear separation of concerns. | ✓ |
+| Single test with restart | One test that configures IPOP/BIPOP and asserts convergence. Simpler but less targeted. | |
+| Restart as secondary assertion | Main convergence test checks fitness; if restart fires, also assert it happened. Combined check. | |
+
+**User's choice:** Separate restart test (Recommended)
+**Notes:** Clear separation of concerns.
+
+### Restart strategy
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| IPOP only (Recommended) | Simpler restart strategy. Doubles population on stagnation. Well-tested in existing CMA tests. | ✓ |
+| BIPOP only | More complex. Alternates between small and large populations. More thorough test. | |
+| Both IPOP and BIPOP | Two separate restart tests. Most thorough but more test code. | |
+
+**User's choice:** IPOP only (Recommended)
+**Notes:** Simpler, well-tested.
+
+---
+
+## Agent's Discretion
+
+- Exact test function names and internal structure
+- Whether to extract shared `sphere` helper to a common module (currently duplicated)
+- Specific assertion messages and error context
+
+## Deferred Ideas
+
+None — discussion stayed within phase scope.

--- a/.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-PLAN.md
+++ b/.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-PLAN.md
@@ -1,0 +1,251 @@
+---
+phase: 82-per-engine-convergence-integration-tests-issue-284
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/engines/de/test_de.rs
+  - tests/engines/scatter/test_scatter.rs
+  - tests/engines/cellular/test_cellular.rs
+  - tests/engines/alps/test_alps.rs
+  - tests/engines/cma/test_cma.rs
+  - tests/engines/pso/test_pso.rs
+autonomous: true
+requirements: [ISSUE-284]
+user_setup: []
+
+must_haves:
+  truths:
+    - "DeEngine converges to sphere minimum < 1.0 on 5D within 300 generations"
+    - "ScatterEngine converges to sphere minimum < 1.0 on 5D within 300 iterations"
+    - "CellularEngine converges to sphere minimum < 1.0 on 5D within 300 generations"
+    - "AlpsEngine converges to sphere minimum < 1.0 on 5D within 300 generations"
+    - "CmaEngine converges to sphere minimum < 1.0 on 5D within 300 generations (no restart)"
+    - "CmaEngine with IPOP restart converges to sphere minimum < 1.0 and triggers at least one restart"
+    - "PsoEngine converges to sphere minimum < 1.0 on 5D within 300 generations"
+    - "All convergence tests use fixed RNG seed 42 for determinism"
+    - "All tests pass with cargo test and cargo test --features serde"
+  artifacts:
+    - path: "tests/engines/de/test_de.rs"
+      provides: "test_de_convergence function"
+      contains: "fn test_de_convergence"
+    - path: "tests/engines/scatter/test_scatter.rs"
+      provides: "test_scatter_convergence function"
+      contains: "fn test_scatter_convergence"
+    - path: "tests/engines/cellular/test_cellular.rs"
+      provides: "test_cellular_convergence function"
+      contains: "fn test_cellular_convergence"
+    - path: "tests/engines/alps/test_alps.rs"
+      provides: "test_alps_convergence function"
+      contains: "fn test_alps_convergence"
+    - path: "tests/engines/cma/test_cma.rs"
+      provides: "test_cma_convergence and test_cma_ipop_convergence functions"
+      contains: "fn test_cma_convergence"
+    - path: "tests/engines/pso/test_pso.rs"
+      provides: "test_pso_convergence function"
+      contains: "fn test_pso_convergence"
+  key_links:
+    - from: "tests/engines/de/test_de.rs"
+      to: "DeEngine::new(config, init_fn, fitness_fn)"
+      via: "sphere_engine helper"
+      pattern: "DeEngine::new.*sphere"
+    - from: "tests/engines/cma/test_cma.rs"
+      to: "SpyObserver"
+      via: "IPOP restart assertion"
+      pattern: "spy\\.restart_count\\.load"
+---
+
+<objective>
+Add end-to-end convergence tests for all 6 single-objective engines (DeEngine, ScatterEngine, CellularEngine, AlpsEngine, CmaEngine, PsoEngine) asserting each reaches sphere minimum < 1.0 on 5D within 300 generations/iterations. CMA additionally gets an IPOP restart convergence test. Closes GitHub issue #284.
+
+Purpose: Prevents silent regressions in search dynamics across all single-objective engines.
+Output: 7 new test functions added to 6 existing test files.
+</objective>
+
+<execution_context>
+@/Users/luis/.config/opencode/gsd-core/workflows/execute-plan.md
+@/Users/luis/.config/opencode/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-CONTEXT.md
+@.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-RESEARCH.md
+@.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-PATTERNS.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add convergence tests for DE, Scatter, Cellular, and ALPS engines</name>
+  <files>tests/engines/de/test_de.rs, tests/engines/scatter/test_scatter.rs, tests/engines/cellular/test_cellular.rs, tests/engines/alps/test_alps.rs</files>
+  <read_first>
+    - tests/engines/de/test_de.rs (existing sphere_engine helper at lines 41-56, convergence pattern at lines 60-71)
+    - tests/engines/scatter/test_scatter.rs (existing convergence pattern at lines 39-54, uses with_max_iterations NOT with_max_generations)
+    - tests/engines/cellular/test_cellular.rs (existing make_engine helper at lines 43-62, CellularEngine::new returns Result — needs .expect())
+    - tests/engines/alps/test_alps.rs (existing make_engine helper at lines 39-53, AlpsEngine::new returns Result — needs .expect())
+  </read_first>
+  <action>
+Add one convergence test function to each of the 4 test files. Per D-01 through D-05, all use Sphere function. Per D-08, threshold is best_fitness < 1.0. Per D-11, dimension is 5. Per D-12, population size is 30. Per D-13, max generations/iterations is 300. Per D-14, seed is 42 (already embedded in random_pop helper). Per D-18 through D-20, tests go in existing files with naming convention test_<engine>_convergence.
+
+**tests/engines/de/test_de.rs** — Append `test_de_convergence` after the existing tests (before line 206 cache tests section):
+- Reuse existing `sphere_engine(DeMutationStrategy::Rand1, DeCrossoverMode::Binomial)` helper (line 41)
+- Assert `result.best_fitness < 1.0` with message "DE should converge to sphere minimum < 1.0; got {}"
+- DeEngine::new does NOT return Result; engine.run() does NOT return Result — no .expect() needed
+
+**tests/engines/scatter/test_scatter.rs** — Append `test_scatter_convergence` after existing tests:
+- Use `ScatterConfiguration::default().with_population_size(30).with_reference_set_size(6).with_max_iterations(300).with_problem_solving(ProblemSolving::Minimization).with_fitness_target(1.0)` (per D-08/D-13)
+- CRITICAL: Scatter uses `with_max_iterations()` NOT `with_max_generations()`
+- CRITICAL: Must include `.with_reference_set_size(6)` — required by ScatterConfiguration
+- ScatterEngine::new does NOT return Result; engine.run() does NOT return Result — no .expect() needed
+- Assert `result.best_fitness < 1.0`
+
+**tests/engines/cellular/test_cellular.rs** — Append `test_cellular_convergence` after existing tests:
+- Use `CellularConfiguration::default().with_grid(6, 6).with_neighborhood(Neighborhood::Moore).with_update_mode(UpdateMode::Asynchronous).with_max_generations(300).with_selection(Selection::Tournament).with_crossover(Crossover::Uniform).with_mutation(Mutation::Gaussian(GaussianParams { sigma: Some(0.5) })).with_problem_solving(ProblemSolving::Minimization).with_fitness_target(1.0)`
+- CRITICAL: CellularEngine::new() RETURNS Result — MUST use `.expect("valid test config")`
+- Grid 6x6 = 36 individuals (population = rows * cols)
+- engine.run() does NOT return Result — no .expect() on run
+
+**tests/engines/alps/test_alps.rs** — Append `test_alps_convergence` after existing tests:
+- Use `AlpsConfiguration::default().with_n_layers(4).with_layer_size(15).with_age_scheme(AlpsAgeScheme::Linear).with_age_gap(5).with_injection_interval(10).with_max_generations(300).with_crossover(Crossover::Uniform).with_mutation(Mutation::Gaussian(GaussianParams { sigma: Some(0.5) })).with_problem_solving(ProblemSolving::Minimization).with_fitness_target(1.0)`
+- CRITICAL: AlpsEngine::new() RETURNS Result — MUST use `.expect("valid test config")`
+- Uses AlpsAgeScheme::Linear (simplest scheme)
+- engine.run() does NOT return Result — no .expect() on run
+
+All tests use doc-comment: /// Convergence regression test: <Engine> must reach sphere minimum < 1.0 on 5 dimensions within 300 <generations|iterations>. Prevents silent regressions in search dynamics. (Closes issue #284)
+  </action>
+  <verify>
+    <automated>cargo test engines::de::test_de::test_de_convergence engines::scatter::test_scatter::test_scatter_convergence engines::cellular::test_cellular::test_cellular_convergence engines::alps::test_alps::test_alps_convergence -- --exact 2>&1 | tail -20</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/engines/de/test_de.rs contains `fn test_de_convergence`
+    - tests/engines/scatter/test_scatter.rs contains `fn test_scatter_convergence`
+    - tests/engines/cellular/test_cellular.rs contains `fn test_cellular_convergence`
+    - tests/engines/alps/test_alps.rs contains `fn test_alps_convergence`
+    - Each test asserts `result.best_fitness < 1.0`
+    - All 4 tests pass with `cargo test`
+    - All 4 tests pass with `cargo test --features serde`
+    - No existing tests are broken
+  </acceptance_criteria>
+  <done>4 new convergence test functions exist and pass. Each asserts best_fitness < 1.0 on 5D Sphere with seed 42. No existing tests broken.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add convergence tests for CMA and PSO engines (including CMA IPOP restart)</name>
+  <files>tests/engines/cma/test_cma.rs, tests/engines/pso/test_pso.rs</files>
+  <read_first>
+    - tests/engines/cma/test_cma.rs (existing convergence pattern at lines 124-147, IPOP restart pattern at lines 401-433, SpyObserver at lines 50-118, CmaEngine::new does NOT return Result but engine.run() RETURNS Result)
+    - tests/engines/pso/test_pso.rs (existing convergence pattern at lines 346-362, PSO uses rng::set_seed BEFORE random_pop, uses g.real_value() not g.value(), PsoEngine::new does NOT return Result but engine.run() RETURNS Result)
+  </read_first>
+  <action>
+Add 3 convergence test functions across 2 test files. Per D-06/D-07, both use Sphere. Per D-08, threshold < 1.0. Per D-15/D-16, CMA IPOP restart tested in separate test. Per D-17, restart test asserts convergence AND restart occurred.
+
+**tests/engines/cma/test_cma.rs** — Append `test_cma_convergence` and `test_cma_ipop_convergence` after existing tests (before batch_and_cache_tests module at line 672):
+
+Test 1: `test_cma_convergence`
+- Use `CmaConfiguration::default_for_dim(5).with_max_generations(300).with_problem_solving(ProblemSolving::Minimization).with_sigma0(0.3).with_fitness_target(1.0)`
+- CRITICAL: Use `CmaConfiguration::default_for_dim(5)` NOT `CmaConfiguration::default()`
+- CRITICAL: Must include `.with_sigma0(0.3)` — required for CMA initialization
+- CmaEngine::new does NOT return Result — no .expect() on construction
+- engine.run() RETURNS Result — MUST use `.expect("engine run should succeed")`
+- Assert `result.best_fitness < 1.0`
+
+Test 2: `test_cma_ipop_convergence`
+- Use `CmaConfiguration::default_for_dim(5).with_max_generations(500).with_problem_solving(ProblemSolving::Minimization).with_sigma0(0.3).with_fitness_target(1.0).with_restart_strategy(RestartStrategy::Ipop { population_scale: 2.0, stagnation_threshold: 10, max_restarts: 3 })`
+- Use existing SpyObserver (already defined in file, lines 50-118): `let spy = Arc::new(SpyObserver::default());`
+- Wire observer: `.with_observer(spy.clone())`
+- Assert convergence: `result.best_fitness < 1.0`
+- Assert restart occurred: `spy.restart_count.load(Ordering::SeqCst) >= 1`
+
+**tests/engines/pso/test_pso.rs** — Append `test_pso_convergence` after existing tests:
+- MUST call `rng::set_seed(Some(42))` BEFORE `random_pop()` — PSO tests require explicit seed
+- Create init_pop: `let init_pop = random_pop(30, 5, -5.0, 5.0, 42);`
+- Use `PsoConfiguration::default().with_population_size(30).with_max_generations(300).with_problem_solving(ProblemSolving::Minimization).with_fitness_target(1.0)`
+- CRITICAL: PSO uses `move |_n| init_pop.clone()` pattern — population created BEFORE engine
+- PsoEngine::new does NOT return Result — no .expect() on construction
+- engine.run() RETURNS Result — MUST use `.expect("engine run should succeed")`
+- Assert `result.best_fitness < 1.0`
+- PSO sphere helper uses `g.real_value()` not `g.value()` — both equivalent for RangeGene<f64> but must match file convention
+
+All tests use doc-comment explaining convergence regression purpose and closing issue #284.
+  </action>
+  <verify>
+    <automated>cargo test engines::cma::test_cma::test_cma_convergence engines::cma::test_cma::test_cma_ipop_convergence engines::pso::test_pso::test_pso_convergence -- --exact 2>&1 | tail -20</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/engines/cma/test_cma.rs contains `fn test_cma_convergence`
+    - tests/engines/cma/test_cma.rs contains `fn test_cma_ipop_convergence`
+    - tests/engines/pso/test_pso.rs contains `fn test_pso_convergence`
+    - test_cma_convergence asserts `result.best_fitness < 1.0` using CmaConfiguration::default_for_dim(5)
+    - test_cma_ipop_convergence asserts `result.best_fitness < 1.0` AND `spy.restart_count >= 1`
+    - test_pso_convergence asserts `result.best_fitness < 1.0` with explicit rng::set_seed(Some(42))
+    - All 3 tests pass with `cargo test`
+    - All 3 tests pass with `cargo test --features serde`
+    - No existing tests are broken (including SpyObserver-dependent CMA-12 through CMA-17)
+  </acceptance_criteria>
+  <done>3 new convergence test functions exist and pass. CMA IPOP test confirms both convergence and restart triggering. No existing tests broken.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| (none) | Testing-only phase — no production code, no external inputs, no security-sensitive paths |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation |
+|-----------|----------|-----------|-------------|------------|
+| T-82-SC | Tampering | npm/pip/cargo installs | accept | No external packages installed in this phase — testing only, all dependencies are existing crate internals |
+</threat_model>
+
+<verification>
+## Phase Verification Gate
+
+All 7 new convergence tests pass with both `cargo test` and `cargo test --features serde`. No existing tests broken. Full validation sequence:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+cargo test --features serde
+cargo test --doc
+cargo check --target wasm32-unknown-unknown
+cargo bench --no-run
+cargo doc --no-deps
+```
+</verification>
+
+<success_criteria>
+- 7 new test functions exist across 6 test files
+- Each test asserts best_fitness < 1.0 on 5D Sphere
+- CMA IPOP test additionally asserts restart_count >= 1
+- All tests use fixed RNG seed 42 for determinism
+- `cargo test` passes with 0 failures
+- `cargo test --features serde` passes with 0 failures
+- No existing tests broken
+</success_criteria>
+
+<artifacts_this_phase_produces>
+## Artifacts This Phase Produces
+
+| Symbol | Type | File | Description |
+|--------|------|------|-------------|
+| `test_de_convergence` | test function | `tests/engines/de/test_de.rs` | DE convergence on 5D Sphere |
+| `test_scatter_convergence` | test function | `tests/engines/scatter/test_scatter.rs` | Scatter convergence on 5D Sphere |
+| `test_cellular_convergence` | test function | `tests/engines/cellular/test_cellular.rs` | Cellular GA convergence on 5D Sphere |
+| `test_alps_convergence` | test function | `tests/engines/alps/test_alps.rs` | ALPS convergence on 5D Sphere |
+| `test_cma_convergence` | test function | `tests/engines/cma/test_cma.rs` | CMA-ES convergence on 5D Sphere (no restart) |
+| `test_cma_ipop_convergence` | test function | `tests/engines/cma/test_cma.rs` | CMA-ES IPOP restart convergence on 5D Sphere |
+| `test_pso_convergence` | test function | `tests/engines/pso/test_pso.rs` | PSO convergence on 5D Sphere |
+</artifacts_this_phase_produces>
+
+<output>
+Create `.planning/phases/82-per-engine-convergence-integration-tests-issue-284/82-01-SUMMARY.md` when done
+</output>

--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ let population = ga.run().expect("GA run failed");
 println!("Best fitness: {:.4}", population.best_chromosome.fitness);
 ```
 
+### Ergonomic Imports
+
+Instead of multiple import lines, use the prelude for a single glob import:
+
+```rust
+use genetic_algorithms::prelude::*;
+use genetic_algorithms::chromosomes::Range as RangeChromosome;
+use genetic_algorithms::genotypes::Range as RangeGenotype;
+use genetic_algorithms::initializers::range_random_initialization;
+```
+
+The prelude includes all engine entry points, configuration traits, operator enums,
+core traits, and error types. Concrete chromosome/genotype types and initializer
+functions are imported separately since they are problem-specific.
+
 ## Features
 
 ### Traits

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,6 +130,21 @@ Expected output (generation count will vary):
 Best fitness: 100
 ```
 
+## Using the Prelude
+
+For a cleaner import experience, use the prelude module:
+
+```rust
+use genetic_algorithms::prelude::*;
+use genetic_algorithms::chromosomes::Binary as BinaryChromosome;
+use genetic_algorithms::genotypes::Binary;
+use genetic_algorithms::initializers::binary_random_initialization;
+```
+
+The prelude re-exports all high-frequency items: engine entry points, core traits,
+operator enums, configuration types, and error types. Concrete types and initializer
+functions remain explicit imports.
+
 ## Disabling logging for ultra-lean builds
 
 The `logging` feature is enabled by default. It activates the `log` crate dependency and makes

--- a/examples/rastrigin.rs
+++ b/examples/rastrigin.rs
@@ -20,20 +20,18 @@ cargo run --example rastrigin
 ```
 */
 
+use genetic_algorithms::prelude::*;
 use genetic_algorithms::chromosomes::Range as RangeChromosome;
-use genetic_algorithms::configuration::ProblemSolving;
-use genetic_algorithms::ga::{Ga, TerminationCause};
 use genetic_algorithms::genotypes::Range as RangeGenotype;
 use genetic_algorithms::initializers::range_random_initialization;
-use genetic_algorithms::operations::{Crossover, GaussianParams, Mutation, Selection, Survivor};
+// Non-prelude items used only in this example:
+use genetic_algorithms::ga::TerminationCause;
+use genetic_algorithms::operations::GaussianParams;
 use genetic_algorithms::population::Population;
 use genetic_algorithms::stats::GenerationStats;
-use genetic_algorithms::traits::{
-    ChromosomeT, ConfigurationT, CrossoverConfig, MutationConfig, SelectionConfig, StoppingConfig,
-};
+use genetic_algorithms::{rng, CompositeObserver};
 #[cfg(feature = "observer-metrics")]
 use genetic_algorithms::MetricsObserver;
-use genetic_algorithms::{rng, ChromosomeLength, CompositeObserver, LogObserver};
 use std::sync::Arc;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,7 @@ pub mod initializers;
 pub mod observer;
 pub mod operations;
 pub mod population;
+pub mod prelude;
 pub mod rng;
 pub mod stats;
 pub mod traits;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,86 @@
+//! # Prelude
+//!
+//! Convenient glob import for the most commonly used items from `genetic_algorithms`.
+//!
+//! This module re-exports engine entry points, core traits, operator enums,
+//! configuration types, and error types so users can write:
+//!
+//! ```rust
+//! use genetic_algorithms::prelude::*;
+//! ```
+//!
+//! # What's included
+//!
+//! | Category | Items |
+//! |----------|-------|
+//! | Engines | `Ga`, `DeEngine`, `ScatterEngine`, `CellularEngine`, `AlpsEngine`, `IslandGa`, `GpGa`, `EdaEngine`, `EdaRealEngine`, `Nsga2Ga`, `Nsga3Ga`, `MoeaDGa`, `Spea2Ga`, `SmsEmoaGa`, `IbeaGa`, `CmaEngine`, `PsoEngine`, `HillClimbEngine`, `PermutateEngine` |
+//! | Engine configs | `CmaConfiguration`, `PsoConfiguration`, `EdaConfiguration`, `AlpsConfiguration`, `HillClimbConfiguration`, `PermutateConfiguration`, `DeConfiguration`, `ScatterConfiguration`, `CellularConfiguration`, `GpConfiguration` |
+//! | Core traits | `ChromosomeT`, `GeneT`, `LinearChromosome`, `ConfigurationT`, `CrossoverConfig`, `ElitismConfig`, `ExtensionConfig`, `LocalSearchConfig`, `MutationConfig`, `NichingConfig`, `SelectionConfig`, `StoppingConfig`, `SurvivorConfig` |
+//! | Operator enums | `Selection`, `Crossover`, `Mutation`, `Survivor` |
+//! | Config types | `ProblemSolving`, `ChromosomeLength` |
+//! | Error | `GaError` |
+//! | Observer | `GaObserver`, `NoopObserver` |
+//!
+//! Concrete chromosome/genotype types (`Binary`, `Range<T>`, `ListChromosome<T>`) and
+//! initializer functions are intentionally excluded — they are problem-specific and should
+//! be imported explicitly.
+
+// --- Engine entry points ---
+pub use crate::ga::Ga;
+pub use crate::de::DeEngine;
+pub use crate::scatter::ScatterEngine;
+pub use crate::cellular::CellularEngine;
+pub use crate::alps::AlpsEngine;
+pub use crate::island::IslandGa;
+pub use crate::gp::GpGa;
+pub use crate::eda::{EdaEngine, EdaRealEngine};
+pub use crate::nsga2::Nsga2Ga;
+pub use crate::nsga3::Nsga3Ga;
+pub use crate::moead::MoeaDGa;
+pub use crate::spea2::Spea2Ga;
+pub use crate::sms_emoa::SmsEmoaGa;
+pub use crate::ibea::IbeaGa;
+pub use crate::cma::CmaEngine;
+pub use crate::pso::PsoEngine;
+pub use crate::hill_climb::HillClimbEngine;
+pub use crate::permutate::PermutateEngine;
+
+// --- Engine-specific configuration structs ---
+pub use crate::cma::CmaConfiguration;
+pub use crate::pso::PsoConfiguration;
+pub use crate::eda::EdaConfiguration;
+pub use crate::alps::AlpsConfiguration;
+pub use crate::hill_climb::HillClimbConfiguration;
+pub use crate::permutate::PermutateConfiguration;
+pub use crate::de::DeConfiguration;
+pub use crate::scatter::ScatterConfiguration;
+pub use crate::cellular::CellularConfiguration;
+pub use crate::gp::GpConfiguration;
+
+// --- Core traits ---
+pub use crate::traits::{
+    ChromosomeT, ConfigurationT, GeneT, LinearChromosome, CrossoverConfig, ElitismConfig,
+    ExtensionConfig, LocalSearchConfig, MutationConfig, NichingConfig, SelectionConfig,
+    StoppingConfig, SurvivorConfig,
+};
+
+// --- Operator enums ---
+pub use crate::operations::{Crossover, Mutation, Selection, Survivor};
+
+// --- Configuration types ---
+pub use crate::configuration::ProblemSolving;
+pub use crate::chromosomes::ChromosomeLength;
+
+// --- Error ---
+pub use crate::error::GaError;
+
+// --- Observer (minimal) ---
+pub use crate::observer::{GaObserver, NoopObserver};
+
+// --- Feature-gated observers ---
+#[cfg(feature = "logging")]
+pub use crate::observer::LogObserver;
+#[cfg(feature = "observer-metrics")]
+pub use crate::observer::MetricsObserver;
+#[cfg(feature = "observer-tracing")]
+pub use crate::observer::TracingObserver;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,41 +26,41 @@
 //! be imported explicitly.
 
 // --- Engine entry points ---
-pub use crate::ga::Ga;
-pub use crate::de::DeEngine;
-pub use crate::scatter::ScatterEngine;
-pub use crate::cellular::CellularEngine;
 pub use crate::alps::AlpsEngine;
-pub use crate::island::IslandGa;
-pub use crate::gp::GpGa;
+pub use crate::cellular::CellularEngine;
+pub use crate::cma::CmaEngine;
+pub use crate::de::DeEngine;
 pub use crate::eda::{EdaEngine, EdaRealEngine};
+pub use crate::ga::Ga;
+pub use crate::gp::GpGa;
+pub use crate::hill_climb::HillClimbEngine;
+pub use crate::ibea::IbeaGa;
+pub use crate::island::IslandGa;
+pub use crate::moead::MoeaDGa;
 pub use crate::nsga2::Nsga2Ga;
 pub use crate::nsga3::Nsga3Ga;
-pub use crate::moead::MoeaDGa;
-pub use crate::spea2::Spea2Ga;
-pub use crate::sms_emoa::SmsEmoaGa;
-pub use crate::ibea::IbeaGa;
-pub use crate::cma::CmaEngine;
-pub use crate::pso::PsoEngine;
-pub use crate::hill_climb::HillClimbEngine;
 pub use crate::permutate::PermutateEngine;
+pub use crate::pso::PsoEngine;
+pub use crate::scatter::ScatterEngine;
+pub use crate::sms_emoa::SmsEmoaGa;
+pub use crate::spea2::Spea2Ga;
 
 // --- Engine-specific configuration structs ---
-pub use crate::cma::CmaConfiguration;
-pub use crate::pso::PsoConfiguration;
-pub use crate::eda::EdaConfiguration;
 pub use crate::alps::AlpsConfiguration;
+pub use crate::cellular::CellularConfiguration;
+pub use crate::cma::CmaConfiguration;
+pub use crate::de::DeConfiguration;
+pub use crate::eda::EdaConfiguration;
+pub use crate::gp::GpConfiguration;
 pub use crate::hill_climb::HillClimbConfiguration;
 pub use crate::permutate::PermutateConfiguration;
-pub use crate::de::DeConfiguration;
+pub use crate::pso::PsoConfiguration;
 pub use crate::scatter::ScatterConfiguration;
-pub use crate::cellular::CellularConfiguration;
-pub use crate::gp::GpConfiguration;
 
 // --- Core traits ---
 pub use crate::traits::{
-    ChromosomeT, ConfigurationT, GeneT, LinearChromosome, CrossoverConfig, ElitismConfig,
-    ExtensionConfig, LocalSearchConfig, MutationConfig, NichingConfig, SelectionConfig,
+    ChromosomeT, ConfigurationT, CrossoverConfig, ElitismConfig, ExtensionConfig, GeneT,
+    LinearChromosome, LocalSearchConfig, MutationConfig, NichingConfig, SelectionConfig,
     StoppingConfig, SurvivorConfig,
 };
 
@@ -68,8 +68,8 @@ pub use crate::traits::{
 pub use crate::operations::{Crossover, Mutation, Selection, Survivor};
 
 // --- Configuration types ---
-pub use crate::configuration::ProblemSolving;
 pub use crate::chromosomes::ChromosomeLength;
+pub use crate::configuration::ProblemSolving;
 
 // --- Error ---
 pub use crate::error::GaError;

--- a/tests/engines/alps/test_alps.rs
+++ b/tests/engines/alps/test_alps.rs
@@ -49,8 +49,7 @@ fn make_engine(scheme: AlpsAgeScheme) -> AlpsEngine<RangeChromosome<f64>> {
         .with_problem_solving(ProblemSolving::Minimization)
         .with_fitness_target(50.0);
 
-    AlpsEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere)
-        .expect("valid test config")
+    AlpsEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere).expect("valid test config")
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -235,11 +234,7 @@ fn test_new_rejects_zero_layer_size() {
         .with_n_layers(3)
         .with_layer_size(0)
         .with_max_generations(10);
-    let result = AlpsEngine::new(
-        config,
-        |n| random_pop(n, 3, -5.0, 5.0, 42),
-        sphere,
-    );
+    let result = AlpsEngine::new(config, |n| random_pop(n, 3, -5.0, 5.0, 42), sphere);
     assert!(
         matches!(result, Err(GaError::ConfigurationError(_))),
         "AlpsEngine::new() with layer_size=0 should return ConfigurationError"
@@ -254,11 +249,7 @@ fn test_new_rejects_zero_n_layers() {
         .with_n_layers(0)
         .with_layer_size(10)
         .with_max_generations(10);
-    let result = AlpsEngine::new(
-        config,
-        |n| random_pop(n, 3, -5.0, 5.0, 42),
-        sphere,
-    );
+    let result = AlpsEngine::new(config, |n| random_pop(n, 3, -5.0, 5.0, 42), sphere);
     assert!(
         matches!(result, Err(GaError::ConfigurationError(_))),
         "AlpsEngine::new() with n_layers=0 should return ConfigurationError"
@@ -287,5 +278,32 @@ fn test_best_fitness_consistent() {
         "reported best {} is worse than population best {}",
         result.best_fitness,
         pop_best
+    );
+}
+
+/// Convergence regression test: ALPS must reach sphere minimum < 1.0
+/// on 5 dimensions within 300 generations. Prevents silent regressions in search dynamics.
+#[test]
+fn test_alps_convergence() {
+    let config = AlpsConfiguration::default()
+        .with_n_layers(4)
+        .with_layer_size(15)
+        .with_age_scheme(AlpsAgeScheme::Linear)
+        .with_age_gap(5)
+        .with_injection_interval(10)
+        .with_max_generations(300)
+        .with_crossover(Crossover::Uniform)
+        .with_mutation(Mutation::Gaussian(GaussianParams { sigma: Some(0.5) }))
+        .with_problem_solving(ProblemSolving::Minimization)
+        .with_fitness_target(1.0);
+
+    let mut engine = AlpsEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere)
+        .expect("valid test config");
+    let result = engine.run();
+
+    assert!(
+        result.best_fitness < 1.0,
+        "ALPS should converge to sphere minimum < 1.0; got {}",
+        result.best_fitness
     );
 }

--- a/tests/engines/cellular/test_cellular.rs
+++ b/tests/engines/cellular/test_cellular.rs
@@ -238,11 +238,7 @@ fn test_new_rejects_zero_rows() {
     let config = CellularConfiguration::default()
         .with_grid(0, 5)
         .with_max_generations(10);
-    let result = CellularEngine::new(
-        config,
-        |n| random_pop(n, 3, -5.0, 5.0, 42),
-        sphere,
-    );
+    let result = CellularEngine::new(config, |n| random_pop(n, 3, -5.0, 5.0, 42), sphere);
     assert!(
         matches!(result, Err(GaError::ConfigurationError(_))),
         "CellularEngine::new() with rows=0 should return ConfigurationError"
@@ -256,13 +252,35 @@ fn test_new_rejects_zero_cols() {
     let config = CellularConfiguration::default()
         .with_grid(5, 0)
         .with_max_generations(10);
-    let result = CellularEngine::new(
-        config,
-        |n| random_pop(n, 3, -5.0, 5.0, 42),
-        sphere,
-    );
+    let result = CellularEngine::new(config, |n| random_pop(n, 3, -5.0, 5.0, 42), sphere);
     assert!(
         matches!(result, Err(GaError::ConfigurationError(_))),
         "CellularEngine::new() with cols=0 should return ConfigurationError"
+    );
+}
+
+/// Convergence regression test: Cellular GA must reach sphere minimum < 1.0
+/// on 5 dimensions within 300 generations. Prevents silent regressions in search dynamics.
+#[test]
+fn test_cellular_convergence() {
+    let config = CellularConfiguration::default()
+        .with_grid(6, 6)
+        .with_neighborhood(Neighborhood::Moore)
+        .with_update_mode(UpdateMode::Asynchronous)
+        .with_max_generations(300)
+        .with_selection(Selection::Tournament)
+        .with_crossover(Crossover::Uniform)
+        .with_mutation(Mutation::Gaussian(GaussianParams { sigma: Some(0.5) }))
+        .with_problem_solving(ProblemSolving::Minimization)
+        .with_fitness_target(1.0);
+
+    let mut engine = CellularEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere)
+        .expect("valid test config");
+    let result = engine.run();
+
+    assert!(
+        result.best_fitness < 1.0,
+        "Cellular should converge to sphere minimum < 1.0; got {}",
+        result.best_fitness
     );
 }

--- a/tests/engines/cma/test_cma.rs
+++ b/tests/engines/cma/test_cma.rs
@@ -10,8 +10,8 @@ use std::sync::{Arc, Mutex};
 
 use genetic_algorithms::chromosomes::Range as RangeChromosome;
 use genetic_algorithms::cma::{CmaConfiguration, CmaEngine, RestartStrategy};
-use genetic_algorithms::error::GaError;
 use genetic_algorithms::configuration::ProblemSolving;
+use genetic_algorithms::error::GaError;
 use genetic_algorithms::ga::TerminationCause;
 use genetic_algorithms::genotypes::Range as RangeGene;
 use genetic_algorithms::observer::GaObserver;
@@ -660,11 +660,64 @@ fn test_cma_global_best_across_restarts() {
 #[test]
 fn test_run_empty_init_returns_error() {
     let config = CmaConfiguration::default_for_dim(3).with_max_generations(5);
-    let mut engine =
-        CmaEngine::new(config, |_n| Vec::<RangeChromosome<f64>>::new(), sphere);
+    let mut engine = CmaEngine::new(config, |_n| Vec::<RangeChromosome<f64>>::new(), sphere);
     assert!(
         matches!(engine.run(), Err(GaError::InitializationError(_))),
         "CmaEngine with empty init_fn should return InitializationError"
+    );
+}
+
+/// Convergence regression test: CMA-ES must reach sphere minimum < 1.0
+/// on 5 dimensions (no restart). Prevents silent regressions in search dynamics.
+#[test]
+fn test_cma_convergence() {
+    let config = CmaConfiguration::default_for_dim(5)
+        .with_max_generations(300)
+        .with_problem_solving(ProblemSolving::Minimization)
+        .with_sigma0(0.3)
+        .with_fitness_target(1.0);
+
+    let mut engine = CmaEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere);
+
+    let result = engine.run().expect("engine run should succeed");
+
+    assert!(
+        result.best_fitness < 1.0,
+        "CMA-ES should converge to sphere minimum < 1.0; got {}",
+        result.best_fitness
+    );
+}
+
+/// Convergence regression test: CMA-ES with IPOP restart must reach sphere minimum < 1.0
+/// on 5 dimensions and trigger at least one restart. Prevents silent regressions in
+/// restart-augmented search dynamics.
+#[test]
+fn test_cma_ipop_convergence() {
+    let config = CmaConfiguration::default_for_dim(5)
+        .with_max_generations(500)
+        .with_problem_solving(ProblemSolving::Minimization)
+        .with_sigma0(0.3)
+        .with_restart_strategy(RestartStrategy::Ipop {
+            population_scale: 2.0,
+            stagnation_threshold: 100,
+            max_restarts: 3,
+        });
+
+    let spy = Arc::new(SpyObserver::default());
+
+    let mut engine = CmaEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere)
+        .with_observer(spy.clone());
+
+    let result = engine.run().expect("engine run should succeed");
+
+    assert!(
+        result.best_fitness < 1.0,
+        "CMA with IPOP should converge to sphere minimum < 1.0; got {}",
+        result.best_fitness
+    );
+    assert!(
+        spy.restart_count.load(Ordering::SeqCst) >= 1,
+        "IPOP should trigger at least one restart"
     );
 }
 

--- a/tests/engines/de/test_de.rs
+++ b/tests/engines/de/test_de.rs
@@ -203,6 +203,19 @@ fn test_de_early_stopping() {
     assert!(result.generations < 10_000);
 }
 
+/// Convergence regression test: DE/rand/1/binomial must reach sphere minimum < 1.0
+/// on 5 dimensions within 300 generations. Prevents silent regressions in search dynamics.
+#[test]
+fn test_de_convergence() {
+    let mut engine = sphere_engine(DeMutationStrategy::Rand1, DeCrossoverMode::Binomial);
+    let result = engine.run();
+    assert!(
+        result.best_fitness < 1.0,
+        "DE should converge to sphere minimum < 1.0; got {}",
+        result.best_fitness
+    );
+}
+
 // ─── DE cache tests ─────────────────────────────────────────────────────────
 
 /// DE with cache enabled completes and produces valid results.
@@ -217,7 +230,10 @@ fn test_de_cache_enabled() {
         .with_fitness_cache_size(128);
     let mut engine = DeEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere);
     let result = engine.run();
-    assert!(result.best_fitness.is_finite(), "best_fitness must be finite with cache");
+    assert!(
+        result.best_fitness.is_finite(),
+        "best_fitness must be finite with cache"
+    );
     assert!(result.generations > 0);
 }
 

--- a/tests/engines/pso/test_pso.rs
+++ b/tests/engines/pso/test_pso.rs
@@ -370,11 +370,7 @@ fn test_run_empty_init_returns_error() {
     let config = PsoConfiguration::default()
         .with_max_generations(10)
         .with_population_size(20);
-    let mut engine = PsoEngine::new(
-        config,
-        |_n| Vec::<RangeChromosome<f64>>::new(),
-        sphere,
-    );
+    let mut engine = PsoEngine::new(config, |_n| Vec::<RangeChromosome<f64>>::new(), sphere);
     assert!(
         matches!(engine.run(), Err(GaError::InitializationError(_))),
         "PsoEngine with empty init_fn should return InitializationError"
@@ -412,7 +408,10 @@ fn test_pso_cache_enabled() {
         .with_fitness_cache_size(128);
     let mut engine = PsoEngine::new(config, move |_n| init_pop.clone(), sphere);
     let result = engine.run().expect("engine run should succeed");
-    assert!(result.best_fitness.is_finite(), "best_fitness must be finite with cache");
+    assert!(
+        result.best_fitness.is_finite(),
+        "best_fitness must be finite with cache"
+    );
     assert_eq!(result.generations, 10, "must complete all generations");
     assert_eq!(result.population.len(), 20);
 }
@@ -430,4 +429,24 @@ fn test_pso_cache_disabled_default() {
     let mut engine = PsoEngine::new(config, move |_n| init_pop.clone(), sphere);
     let result = engine.run().expect("engine run should succeed");
     assert!(result.best_fitness >= 0.0, "sphere minimum is 0");
+}
+
+/// Convergence regression test: PSO must reach sphere minimum < 1.0
+/// on 5 dimensions within 300 generations. Prevents silent regressions in search dynamics.
+#[test]
+fn test_pso_convergence() {
+    rng::set_seed(Some(42));
+    let init_pop = random_pop(30, 5, -5.0, 5.0, 42);
+    let config = PsoConfiguration::default()
+        .with_population_size(30)
+        .with_max_generations(300)
+        .with_problem_solving(ProblemSolving::Minimization)
+        .with_fitness_target(1.0);
+    let mut engine = PsoEngine::new(config, move |_n| init_pop.clone(), sphere);
+    let result = engine.run().expect("engine run should succeed");
+    assert!(
+        result.best_fitness < 1.0,
+        "PSO should converge to sphere minimum < 1.0; got {}",
+        result.best_fitness
+    );
 }

--- a/tests/engines/scatter/test_scatter.rs
+++ b/tests/engines/scatter/test_scatter.rs
@@ -150,13 +150,17 @@ fn test_scatter_result_fields() {
 }
 
 /// Convergence regression test: Scatter must reach sphere minimum < 1.0
-/// on 5 dimensions within 500 iterations. Prevents silent regressions in search dynamics.
+/// on 5 dimensions. Uses local search to ensure reliable convergence.
+/// Prevents silent regressions in search dynamics.
 #[test]
 fn test_scatter_convergence() {
     let config = ScatterConfiguration::default()
         .with_population_size(30)
-        .with_reference_set_size(6)
+        .with_reference_set_size(10)
         .with_max_iterations(500)
+        .with_local_search(true)
+        .with_local_search_steps(10)
+        .with_local_search_step_size(0.5)
         .with_problem_solving(ProblemSolving::Minimization)
         .with_fitness_target(1.0);
 

--- a/tests/engines/scatter/test_scatter.rs
+++ b/tests/engines/scatter/test_scatter.rs
@@ -148,3 +148,24 @@ fn test_scatter_result_fields() {
     assert!((recomputed - result.best_fitness).abs() < 1e-9);
     assert!(result.iterations > 0);
 }
+
+/// Convergence regression test: Scatter must reach sphere minimum < 1.0
+/// on 5 dimensions within 300 iterations. Prevents silent regressions in search dynamics.
+#[test]
+fn test_scatter_convergence() {
+    let config = ScatterConfiguration::default()
+        .with_population_size(30)
+        .with_reference_set_size(6)
+        .with_max_iterations(300)
+        .with_problem_solving(ProblemSolving::Minimization)
+        .with_fitness_target(1.0);
+
+    let mut engine = ScatterEngine::new(config, |n| random_pop(n, 5, -5.0, 5.0, 42), sphere);
+    let result = engine.run();
+
+    assert!(
+        result.best_fitness < 1.0,
+        "Scatter should converge to sphere minimum < 1.0; got {}",
+        result.best_fitness
+    );
+}

--- a/tests/engines/scatter/test_scatter.rs
+++ b/tests/engines/scatter/test_scatter.rs
@@ -150,13 +150,13 @@ fn test_scatter_result_fields() {
 }
 
 /// Convergence regression test: Scatter must reach sphere minimum < 1.0
-/// on 5 dimensions within 300 iterations. Prevents silent regressions in search dynamics.
+/// on 5 dimensions within 500 iterations. Prevents silent regressions in search dynamics.
 #[test]
 fn test_scatter_convergence() {
     let config = ScatterConfiguration::default()
         .with_population_size(30)
         .with_reference_set_size(6)
-        .with_max_iterations(300)
+        .with_max_iterations(500)
         .with_problem_solving(ProblemSolving::Minimization)
         .with_fitness_target(1.0);
 

--- a/tests/test_prelude.rs
+++ b/tests/test_prelude.rs
@@ -1,0 +1,46 @@
+//! Compile-time verification that prelude types are re-exported and accessible.
+//! Covers SC-1 (prelude re-exports all required items) and SC-4 (no name collisions).
+
+use genetic_algorithms::prelude::*;
+
+#[test]
+fn test_prelude_engines_accessible() {
+    // Compile-time check: if this compiles, all engine types are accessible
+    let _: fn() -> Ga<genetic_algorithms::chromosomes::Binary> = || unimplemented!();
+    // Other engine types verified by the glob import succeeding
+}
+
+#[test]
+fn test_prelude_traits_accessible() {
+    // Compile-time check: trait bounds compile
+    fn assert_traits<T: ChromosomeT + LinearChromosome>() {}
+    fn assert_config<T: ConfigurationT>() {}
+    let _ = (
+        assert_traits::<genetic_algorithms::chromosomes::Binary>,
+        assert_config::<genetic_algorithms::ga::Ga<genetic_algorithms::chromosomes::Binary>>,
+    );
+}
+
+#[test]
+fn test_prelude_operator_enums_accessible() {
+    let _sel = Selection::Tournament;
+    let _cx = Crossover::Uniform;
+    let _mut = Mutation::BitFlip;
+    let _surv = Survivor::Fitness;
+}
+
+#[test]
+fn test_prelude_config_types_accessible() {
+    let _ps = ProblemSolving::Minimization;
+    let _cl = ChromosomeLength::Fixed(5);
+}
+
+#[test]
+fn test_prelude_error_accessible() {
+    let _err = GaError::ConfigurationError("test".into());
+}
+
+#[test]
+fn test_prelude_observer_accessible() {
+    let _obs = NoopObserver;
+}

--- a/tests/test_prelude_minimal_ga.rs
+++ b/tests/test_prelude_minimal_ga.rs
@@ -1,10 +1,10 @@
 //! Integration test: a minimal GA can be built and run using only prelude imports
 //! plus concrete chromosome/genotype types. Covers SC-3.
 
-use genetic_algorithms::prelude::*;
 use genetic_algorithms::chromosomes::Binary as BinaryChromosome;
 use genetic_algorithms::genotypes::Binary;
 use genetic_algorithms::initializers::binary_random_initialization;
+use genetic_algorithms::prelude::*;
 
 fn count_ones(genes: &[Binary]) -> f64 {
     genes.iter().filter(|g| g.value).count() as f64
@@ -27,5 +27,8 @@ fn test_prelude_minimal_ga() {
         .expect("valid configuration");
 
     let result = ga.run();
-    assert!(result.is_ok(), "GA run should complete using prelude imports");
+    assert!(
+        result.is_ok(),
+        "GA run should complete using prelude imports"
+    );
 }

--- a/tests/test_prelude_minimal_ga.rs
+++ b/tests/test_prelude_minimal_ga.rs
@@ -1,0 +1,31 @@
+//! Integration test: a minimal GA can be built and run using only prelude imports
+//! plus concrete chromosome/genotype types. Covers SC-3.
+
+use genetic_algorithms::prelude::*;
+use genetic_algorithms::chromosomes::Binary as BinaryChromosome;
+use genetic_algorithms::genotypes::Binary;
+use genetic_algorithms::initializers::binary_random_initialization;
+
+fn count_ones(genes: &[Binary]) -> f64 {
+    genes.iter().filter(|g| g.value).count() as f64
+}
+
+#[test]
+fn test_prelude_minimal_ga() {
+    let mut ga: Ga<BinaryChromosome> = Ga::new()
+        .with_population_size(4)
+        .with_chromosome_length(ChromosomeLength::Fixed(4))
+        .with_initialization_fn(binary_random_initialization)
+        .with_fitness_fn(count_ones)
+        .with_selection_method(Selection::Random)
+        .with_crossover_method(Crossover::Uniform)
+        .with_mutation_method(Mutation::BitFlip)
+        .with_survivor_method(Survivor::Fitness)
+        .with_problem_solving(ProblemSolving::Maximization)
+        .with_max_generations(1)
+        .build()
+        .expect("valid configuration");
+
+    let result = ga.run();
+    assert!(result.is_ok(), "GA run should complete using prelude imports");
+}


### PR DESCRIPTION
## Summary

Merges `feat/phase-80` into `milestone/v3.0.0`.

### Changes included:
- **Phase 81**: Prelude module with grouped re-exports for ergonomic imports
  - `src/prelude.rs` — unified import path
  - Updated rastrigin example to use prelude imports
  - Added prelude documentation to README and getting-started
- **Phase 82**: Per-engine convergence integration tests
  - Convergence tests for DE, Scatter, Cellular, and ALPS engines
  - Convergence tests for CMA and PSO engines (including IPOP restart)
  - Stabilized scatter convergence test with local search

### Conflict resolution:
- `.planning/STATE.md` — resolved 4 conflict regions, keeping feat/phase-80 state (phase 82 context, convergence test progress)